### PR TITLE
fix(models): hydrate nested model collections in UDFs

### DIFF
--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -615,7 +615,11 @@ class SignalSchema:
                 obj, pos = self._hydrate_model(fr, is_optional, row, pos, label=name)
                 objs.append(obj)
             else:
-                objs.append(row[pos])
+                objs.append(
+                    self._convert_feature_value(
+                        fr_type, row[pos], catalog=None, cache=False
+                    )
+                )
                 pos += 1
         return objs
 
@@ -763,7 +767,7 @@ class SignalSchema:
         self,
         annotation: DataType,
         value: Any,
-        catalog: "Catalog",
+        catalog: "Catalog | None",
         cache: bool,
     ) -> Any:
         """Convert raw DB value into declared annotation if needed."""
@@ -789,7 +793,8 @@ class SignalSchema:
             else:
                 return result
             assert isinstance(obj, BaseModel)
-            SignalSchema._set_file_stream(obj, catalog, cache)
+            if catalog is not None:
+                SignalSchema._set_file_stream(obj, catalog, cache)
             result = obj
         elif origin is list:
             args = get_args(annotation)

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -3,11 +3,12 @@ import hashlib
 import logging
 import math
 import types
+import typing
 import warnings
-from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from functools import cached_property
+from functools import cached_property, lru_cache
 from inspect import isclass
 from typing import (
     IO,
@@ -20,6 +21,7 @@ from typing import (
     get_origin,
 )
 
+from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 from pydantic import BaseModel, Field, ValidationError, create_model
 from sqlalchemy import Cast, asc, cast, desc, nulls_last
 from sqlalchemy.sql.elements import BinaryExpression, Grouping, Label
@@ -615,13 +617,65 @@ class SignalSchema:
                 obj, pos = self._hydrate_model(fr, is_optional, row, pos, label=name)
                 objs.append(obj)
             else:
-                objs.append(
-                    self._convert_feature_value(
-                        fr_type, row[pos], catalog=None, cache=False
+                value = row[pos]
+                if self._requires_feature_conversion(fr_type):
+                    value = self._convert_feature_value(
+                        fr_type, value, catalog=None, cache=False
                     )
-                )
+                objs.append(value)
                 pos += 1
         return objs
+
+    @classmethod
+    def _requires_feature_conversion(cls, annotation: DataType) -> bool:
+        if ModelStore.is_pydantic(annotation):
+            return True
+
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+        if origin in (Union, types.UnionType):
+            inner, has_none = unwrap_optional(annotation)
+            return has_none and cls._requires_feature_conversion(inner)
+        if origin is list:
+            return bool(args) and cls._requires_feature_conversion(args[0])
+        if origin is dict and len(args) == 2:
+            key_type, value_type = args
+            return key_type is not str or cls._requires_feature_conversion(value_type)
+        return False
+
+    @staticmethod
+    def _annotation_contains_type(annotation: Any, target: type) -> bool:
+        return SignalSchema._annotation_contains_type_cached(
+            typing.cast("Hashable", annotation), target
+        )
+
+    @staticmethod
+    @lru_cache
+    def _annotation_contains_type_cached(annotation: Hashable, target: type) -> bool:
+        def contains(current: Any, seen: set[type]) -> bool:
+            if isclass(current) and issubclass(current, target):
+                return True
+
+            origin = get_origin(current)
+            if origin in (Union, types.UnionType, list, dict, tuple, set):
+                return any(
+                    arg is not Ellipsis
+                    and arg is not type(None)
+                    and contains(arg, seen)
+                    for arg in get_args(current)
+                )
+
+            model = ModelStore.to_pydantic(current)
+            if model is None or model in seen:
+                return False
+            seen.add(model)
+            return any(
+                contains(field.annotation, seen)
+                for field in model.model_fields.values()
+                if field.annotation is not None
+            )
+
+        return contains(annotation, set())
 
     @staticmethod
     def _all_values_none(value: Any) -> bool:
@@ -830,17 +884,50 @@ class SignalSchema:
 
     @staticmethod
     def _set_file_stream(
-        obj: BaseModel, catalog: "Catalog", cache: bool = False
+        obj: Any,
+        catalog: "Catalog",
+        cache: bool = False,
+        download_cb: Callback = DEFAULT_CALLBACK,
+        annotation: DataType | None = None,
+        _seen: set[int] | None = None,
     ) -> None:
+        seen = _seen if _seen is not None else set()
+        if id(obj) in seen:
+            return
+        seen.add(id(obj))
+
         if isinstance(obj, File):
-            obj._set_stream(catalog, caching_enabled=cache)
-        for field, finfo in type(obj).model_fields.items():
-            # Unwrap Optional so a File under Optional[...] still gets its stream.
-            inner, _ = unwrap_optional(finfo.annotation)
-            if ModelStore.is_pydantic(inner):
-                value = getattr(obj, field)
-                if value is not None:
-                    SignalSchema._set_file_stream(value, catalog, cache)
+            obj._set_stream(catalog, caching_enabled=cache, download_cb=download_cb)
+
+        if isinstance(obj, BaseModel):
+            for field, finfo in type(obj).model_fields.items():
+                field_annotation = finfo.annotation
+                if (
+                    field_annotation is not None
+                    and SignalSchema._annotation_contains_type(field_annotation, File)
+                ):
+                    SignalSchema._set_file_stream(
+                        getattr(obj, field),
+                        catalog,
+                        cache,
+                        download_cb,
+                        field_annotation,
+                        seen,
+                    )
+        elif isinstance(obj, Mapping):
+            args = get_args(annotation) if annotation is not None else ()
+            value_annotation = args[1] if len(args) == 2 else None
+            for value in obj.values():
+                SignalSchema._set_file_stream(
+                    value, catalog, cache, download_cb, value_annotation, seen
+                )
+        elif isinstance(obj, (list, tuple, set)):
+            args = get_args(annotation) if annotation is not None else ()
+            item_annotation = args[0] if args else None
+            for value in obj:
+                SignalSchema._set_file_stream(
+                    value, catalog, cache, download_cb, item_annotation, seen
+                )
 
     def get_column_type(self, col_name: str, with_subtree: bool = False) -> DataType:
         """

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -3,7 +3,6 @@ import hashlib
 import logging
 import math
 import types
-import typing
 import warnings
 from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
@@ -20,6 +19,7 @@ from typing import (
     get_args,
     get_origin,
 )
+from typing import cast as typing_cast
 
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 from pydantic import BaseModel, Field, ValidationError, create_model
@@ -618,7 +618,7 @@ class SignalSchema:
                 objs.append(obj)
             else:
                 value = row[pos]
-                if self._requires_feature_conversion(fr_type):
+                if self._row_conversion_required[name]:
                     value = self._convert_feature_value(
                         fr_type, value, catalog=None, cache=False
                     )
@@ -626,8 +626,15 @@ class SignalSchema:
                 pos += 1
         return objs
 
+    @cached_property
+    def _row_conversion_required(self) -> dict[str, bool]:
+        return {
+            name: self._requires_row_conversion(annotation)
+            for name, annotation in self.values.items()
+        }
+
     @classmethod
-    def _requires_feature_conversion(cls, annotation: DataType) -> bool:
+    def _requires_row_conversion(cls, annotation: DataType) -> bool:
         if ModelStore.is_pydantic(annotation):
             return True
 
@@ -635,23 +642,17 @@ class SignalSchema:
         args = get_args(annotation)
         if origin in (Union, types.UnionType):
             inner, has_none = unwrap_optional(annotation)
-            return has_none and cls._requires_feature_conversion(inner)
+            return has_none and cls._requires_row_conversion(inner)
         if origin is list:
-            return bool(args) and cls._requires_feature_conversion(args[0])
+            return bool(args) and cls._requires_row_conversion(args[0])
         if origin is dict and len(args) == 2:
             key_type, value_type = args
-            return key_type is not str or cls._requires_feature_conversion(value_type)
+            return key_type is not str or cls._requires_row_conversion(value_type)
         return False
 
     @staticmethod
-    def _annotation_contains_type(annotation: Any, target: type) -> bool:
-        return SignalSchema._annotation_contains_type_cached(
-            typing.cast("Hashable", annotation), target
-        )
-
-    @staticmethod
     @lru_cache
-    def _annotation_contains_type_cached(annotation: Hashable, target: type) -> bool:
+    def _annotation_contains_type(annotation: Hashable, target: type) -> bool:
         def contains(current: Any, seen: set[type]) -> bool:
             if isclass(current) and issubclass(current, target):
                 return True
@@ -904,7 +905,9 @@ class SignalSchema:
                 field_annotation = finfo.annotation
                 if (
                     field_annotation is not None
-                    and SignalSchema._annotation_contains_type(field_annotation, File)
+                    and SignalSchema._annotation_contains_type(
+                        typing_cast("Hashable", field_annotation), File
+                    )
                 ):
                     SignalSchema._set_file_stream(
                         getattr(obj, field),

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -23,7 +23,7 @@ from datachain.lib.convert.flatten import (
     flatten_value,
     is_optional_model,
 )
-from datachain.lib.file import DataModel, File, FileError
+from datachain.lib.file import File, FileError
 from datachain.lib.utils import AbstractUDF, DataChainParamsError
 from datachain.query.batch import (
     Batch,
@@ -396,7 +396,7 @@ class UDFBase(AbstractUDF):
         if isinstance(obj, File):
             obj._set_stream(catalog, caching_enabled=cache, download_cb=download_cb)
 
-        if isinstance(obj, DataModel):
+        if isinstance(obj, BaseModel):
             for field_name in type(obj).model_fields:
                 self._set_stream_recursive(
                     getattr(obj, field_name, None), catalog, cache, download_cb

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -24,6 +24,7 @@ from datachain.lib.convert.flatten import (
     is_optional_model,
 )
 from datachain.lib.file import File, FileError
+from datachain.lib.signal_schema import SignalSchema
 from datachain.lib.utils import AbstractUDF, DataChainParamsError
 from datachain.query.batch import (
     Batch,
@@ -45,7 +46,6 @@ if TYPE_CHECKING:
     from datachain.cache import Cache
     from datachain.catalog import Catalog
     from datachain.lib.settings import Settings
-    from datachain.lib.signal_schema import SignalSchema
     from datachain.lib.udf_signature import UdfSignature
     from datachain.query.batch import RowsOutput
 
@@ -385,28 +385,29 @@ class UDFBase(AbstractUDF):
         assert self.params
         row = [row_dict[p] for p in self.params.to_udf_spec()]
         obj_row = self.params.row_to_objs(row)
-        for obj in obj_row:
-            self._set_stream_recursive(obj, catalog, cache, download_cb)
+        for obj, annotation in zip(obj_row, self.params.values.values(), strict=True):
+            if self.params._annotation_contains_type(annotation, File):
+                self._set_stream_recursive(
+                    obj, catalog, cache, download_cb, annotation=annotation
+                )
         return obj_row
 
     def _set_stream_recursive(
-        self, obj: Any, catalog: "Catalog", cache: bool, download_cb: Callback
+        self,
+        obj: Any,
+        catalog: "Catalog",
+        cache: bool,
+        download_cb: Callback,
+        annotation: Any = None,
     ) -> None:
         """Recursively set the catalog stream on all File objects within an object."""
-        if isinstance(obj, File):
-            obj._set_stream(catalog, caching_enabled=cache, download_cb=download_cb)
-
-        if isinstance(obj, BaseModel):
-            for field_name in type(obj).model_fields:
-                self._set_stream_recursive(
-                    getattr(obj, field_name, None), catalog, cache, download_cb
-                )
-        elif isinstance(obj, Mapping):
-            for value in obj.values():
-                self._set_stream_recursive(value, catalog, cache, download_cb)
-        elif isinstance(obj, (list, tuple, set)):
-            for value in obj:
-                self._set_stream_recursive(value, catalog, cache, download_cb)
+        SignalSchema._set_file_stream(
+            obj,
+            catalog,
+            cache,
+            download_cb=download_cb,
+            annotation=annotation,
+        )
 
     def _prepare_row(
         self, row, udf_fields, catalog, cache, download_cb, include_id=False

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -396,12 +396,17 @@ class UDFBase(AbstractUDF):
         if isinstance(obj, File):
             obj._set_stream(catalog, caching_enabled=cache, download_cb=download_cb)
 
-        # Check all fields for nested File objects, but only for DataModel objects
         if isinstance(obj, DataModel):
             for field_name in type(obj).model_fields:
-                field_value = getattr(obj, field_name, None)
-                if isinstance(field_value, DataModel):
-                    self._set_stream_recursive(field_value, catalog, cache, download_cb)
+                self._set_stream_recursive(
+                    getattr(obj, field_name, None), catalog, cache, download_cb
+                )
+        elif isinstance(obj, Mapping):
+            for value in obj.values():
+                self._set_stream_recursive(value, catalog, cache, download_cb)
+        elif isinstance(obj, (list, tuple, set)):
+            for value in obj:
+                self._set_stream_recursive(value, catalog, cache, download_cb)
 
     def _prepare_row(
         self, row, udf_fields, catalog, cache, download_cb, include_id=False

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -7,7 +7,7 @@ from contextlib import closing, nullcontext
 from dataclasses import dataclass
 from functools import partial
 from graphlib import CycleError, TopologicalSorter
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import attrs
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
@@ -386,28 +386,17 @@ class UDFBase(AbstractUDF):
         row = [row_dict[p] for p in self.params.to_udf_spec()]
         obj_row = self.params.row_to_objs(row)
         for obj, annotation in zip(obj_row, self.params.values.values(), strict=True):
-            if self.params._annotation_contains_type(annotation, File):
-                self._set_stream_recursive(
-                    obj, catalog, cache, download_cb, annotation=annotation
+            if self.params._annotation_contains_type(
+                cast("abc.Hashable", annotation), File
+            ):
+                SignalSchema._set_file_stream(
+                    obj,
+                    catalog,
+                    cache,
+                    download_cb=download_cb,
+                    annotation=annotation,
                 )
         return obj_row
-
-    def _set_stream_recursive(
-        self,
-        obj: Any,
-        catalog: "Catalog",
-        cache: bool,
-        download_cb: Callback,
-        annotation: Any = None,
-    ) -> None:
-        """Recursively set the catalog stream on all File objects within an object."""
-        SignalSchema._set_file_stream(
-            obj,
-            catalog,
-            cache,
-            download_cb=download_cb,
-            annotation=annotation,
-        )
 
     def _prepare_row(
         self, row, udf_fields, catalog, cache, download_cb, include_id=False

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -913,6 +913,26 @@ def test_map(test_session):
         assert x.my_name == test_fr.my_name
 
 
+def test_map_hydrates_models_in_nested_collection_param(test_session):
+    class ModelCollection(DataModel):
+        items: list[MyFr]
+
+    def get_count(items: list[MyFr]) -> int:
+        assert isinstance(items[0], MyFr)
+        return items[0].count
+
+    chain = dc.read_values(
+        collection=[ModelCollection(items=[MyFr(nnn="item", count=2)])],
+        session=test_session,
+    ).map(
+        get_count,
+        params=["collection.items"],
+        output={"count": int},
+    )
+
+    assert chain.to_values("count") == [2]
+
+
 def test_map_multiple_signals(test_session):
     chain = dc.read_values(name=["foo.txt", "bar.md"], session=test_session).map(
         stem=lambda name: name.rsplit(".", 1)[0],

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -933,6 +933,50 @@ def test_map_hydrates_models_in_nested_collection_param(test_session):
     assert chain.to_values("count") == [2]
 
 
+def test_map_hydrates_models_in_optional_dict_param(test_session):
+    class ModelCollection(DataModel):
+        lookup: dict[str, MyFr] | None
+
+    def get_count(lookup: dict[str, MyFr] | None) -> int:
+        assert lookup is not None
+        return lookup["item"].count
+
+    chain = dc.read_values(
+        collection=[ModelCollection(lookup={"item": MyFr(nnn="item", count=3)})],
+        session=test_session,
+    ).map(
+        get_count,
+        params=["collection.lookup"],
+        output={"count": int},
+    )
+
+    assert chain.to_values("count") == [3]
+
+
+def test_map_reads_file_in_nested_collection(test_session, tmp_path):
+    class FileCollection(DataModel):
+        files: list[File]
+
+    path = tmp_path / "nested.txt"
+    path.write_text("contents")
+
+    chain = (
+        dc.read_storage(tmp_path.as_uri(), session=test_session)
+        .map(
+            collection=lambda file: FileCollection(files=[file]),
+            params=["file"],
+            output={"collection": FileCollection},
+        )
+        .map(
+            content=lambda files: files[0].read().decode(),
+            params=["collection.files"],
+            output={"content": str},
+        )
+    )
+
+    assert chain.to_values("content") == ["contents"]
+
+
 def test_map_multiple_signals(test_session):
     chain = dc.read_values(name=["foo.txt", "bar.md"], session=test_session).map(
         stem=lambda name: name.rsplit(".", 1)[0],

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -911,7 +911,7 @@ def test_map(test_session):
         assert x.my_name == test_fr.my_name
 
 
-def test_map_hydrates_models_in_nested_collection_param(test_session):
+def test_map_converts_nested_collection_items_to_models(test_session):
     class ModelCollection(DataModel):
         items: list[MyFr]
 

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1012,6 +1012,26 @@ def test_row_to_features_optional_collection(test_session):
     assert isinstance(items[0], MyType1)
 
 
+def test_row_to_features_sets_stream_in_model_collection(test_session):
+    class FileCollection(DataModel):
+        files: list[File]
+
+    file = File(path="nested.txt")
+    schema = SignalSchema({"collection": FileCollection})
+
+    (collection,) = schema.row_to_features(([file.model_dump()],), test_session.catalog)
+
+    assert collection.files[0]._catalog is test_session.catalog
+
+
+def test_row_to_objs_preserves_plain_collection():
+    values = [1.0, 2.0]
+
+    (converted,) = SignalSchema({"values": list[float]}).row_to_objs((values,))
+
+    assert converted is values
+
+
 @pytest.mark.parametrize(
     "union_type,union_name",
     [

--- a/tests/unit/lib/test_udf.py
+++ b/tests/unit/lib/test_udf.py
@@ -3,9 +3,10 @@ import pickle
 import pytest
 from cloudpickle import dumps, loads
 from fsspec.callbacks import DEFAULT_CALLBACK
+from pydantic import BaseModel
 
 import datachain as dc
-from datachain import DataModel, Mapper
+from datachain import Mapper
 from datachain.lib.file import File
 from datachain.lib.udf import JsonSerializationError, UDFBase, UdfError, UdfRunError
 from datachain.lib.utils import DataChainError
@@ -133,7 +134,7 @@ def test_udf_verbose_name_unknown():
 
 
 def test_udf_sets_streams_in_nested_collections():
-    class FileHolder(DataModel):
+    class FileHolder(BaseModel):
         file: File
 
     def process(value: str) -> int:
@@ -142,13 +143,12 @@ def test_udf_sets_streams_in_nested_collections():
     sign = get_sign(process, output="res")
     udf = UDFBase._create(sign, sign.output_schema)
     file = File(path="nested.txt")
+    holder = FileHolder(file=file)
     catalog = object()
 
-    udf._set_stream_recursive(
-        [{"holder": FileHolder(file=file)}], catalog, False, DEFAULT_CALLBACK
-    )
+    udf._set_stream_recursive([{"holder": holder}], catalog, False, DEFAULT_CALLBACK)
 
-    assert file._catalog is catalog
+    assert holder.file._catalog is catalog
 
 
 def test_udf_output_type_error_message(monkeypatch, test_session):

--- a/tests/unit/lib/test_udf.py
+++ b/tests/unit/lib/test_udf.py
@@ -7,7 +7,9 @@ from pydantic import BaseModel
 
 import datachain as dc
 from datachain import Mapper
+from datachain.dataset import RowDict
 from datachain.lib.file import File
+from datachain.lib.signal_schema import SignalSchema
 from datachain.lib.udf import JsonSerializationError, UDFBase, UdfError, UdfRunError
 from datachain.lib.utils import DataChainError
 
@@ -149,6 +151,15 @@ def test_udf_sets_streams_in_nested_collections():
     udf._set_stream_recursive([{"holder": holder}], catalog, False, DEFAULT_CALLBACK)
 
     assert holder.file._catalog is catalog
+
+
+def test_udf_does_not_traverse_setup_value():
+    value = {}
+    value["self"] = value
+    udf = UDFBase()
+    udf.params = SignalSchema({"config": str}, setup={"config": lambda: value})
+
+    assert udf._parse_row(RowDict(), object(), False, DEFAULT_CALLBACK) == [value]
 
 
 def test_udf_output_type_error_message(monkeypatch, test_session):

--- a/tests/unit/lib/test_udf.py
+++ b/tests/unit/lib/test_udf.py
@@ -2,9 +2,10 @@ import pickle
 
 import pytest
 from cloudpickle import dumps, loads
+from fsspec.callbacks import DEFAULT_CALLBACK
 
 import datachain as dc
-from datachain import Mapper
+from datachain import DataModel, Mapper
 from datachain.lib.file import File
 from datachain.lib.udf import JsonSerializationError, UDFBase, UdfError, UdfRunError
 from datachain.lib.utils import DataChainError
@@ -129,6 +130,25 @@ def test_udf_verbose_name_unknown():
     udf = UDFBase._create(sign, sign.output_schema)
     udf._func = None
     assert udf.verbose_name == "<unknown>"
+
+
+def test_udf_sets_streams_in_nested_collections():
+    class FileHolder(DataModel):
+        file: File
+
+    def process(value: str) -> int:
+        return len(value)
+
+    sign = get_sign(process, output="res")
+    udf = UDFBase._create(sign, sign.output_schema)
+    file = File(path="nested.txt")
+    catalog = object()
+
+    udf._set_stream_recursive(
+        [{"holder": FileHolder(file=file)}], catalog, False, DEFAULT_CALLBACK
+    )
+
+    assert file._catalog is catalog
 
 
 def test_udf_output_type_error_message(monkeypatch, test_session):

--- a/tests/unit/lib/test_udf.py
+++ b/tests/unit/lib/test_udf.py
@@ -139,16 +139,13 @@ def test_udf_sets_streams_in_nested_collections():
     class FileHolder(BaseModel):
         file: File
 
-    def process(value: str) -> int:
-        return len(value)
-
-    sign = get_sign(process, output="res")
-    udf = UDFBase._create(sign, sign.output_schema)
     file = File(path="nested.txt")
     holder = FileHolder(file=file)
     catalog = object()
 
-    udf._set_stream_recursive([{"holder": holder}], catalog, False, DEFAULT_CALLBACK)
+    SignalSchema._set_file_stream(
+        [{"holder": holder}], catalog, annotation=list[dict[str, FileHolder]]
+    )
 
     assert holder.file._catalog is catalog
 


### PR DESCRIPTION
## Root cause

UDF parameter preparation reconstructed top-level model parameters but passed collection-valued leaves through unchanged. A nested field such as `list[DataModel]` therefore reached the UDF as raw dictionaries. Stream hydration also only followed direct model fields, so `File` values inside model collections did not receive a catalog stream.

The first fix traversed every runtime mapping and collection on every row. That introduced unnecessary collection copies and could recursively walk large or cyclic setup values unrelated to the declared UDF schema.

## Changes

- Convert collection leaves only when their declared annotation requires model hydration or non-string key conversion; preserve ordinary collection objects unchanged.
- Detect model and `File` paths from the declared annotation, with cached and cycle-safe annotation inspection.
- Consolidate stream hydration in `SignalSchema` and use it from both feature conversion and UDF input preparation.
- Traverse nested model/collection/optional annotations only when they can contain `File`, while propagating `download_cb`.
- Avoid traversing arbitrary setup and plain collection values.
- Add regressions for optional dictionaries, nested model collections, plain collection identity, cyclic setup data, and reading a real nested `File` through `map()`.

## Tests

- `pytest -q tests/unit/lib/test_signal_schema.py tests/unit/lib/test_udf.py tests/unit/lib/test_datachain.py` — 495 passed
- `ruff check src/datachain/lib/signal_schema.py src/datachain/lib/udf.py tests/unit/lib/test_signal_schema.py tests/unit/lib/test_udf.py tests/unit/lib/test_datachain.py`
- `ruff format --check src/datachain/lib/signal_schema.py src/datachain/lib/udf.py tests/unit/lib/test_signal_schema.py tests/unit/lib/test_udf.py tests/unit/lib/test_datachain.py`
- `mypy src/datachain/lib/signal_schema.py src/datachain/lib/udf.py --ignore-missing-imports`
- `git diff --check`

## Related

Addresses the performance, setup-recursion, shared traversal, and test-gap findings in the [maintainer review](https://github.com/datachain-ai/datachain/pull/1867#issuecomment-5040057793).
