### PR TITLE
fix: verify registered models against the stored spec on deserialization

### DIFF
--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -2,6 +2,7 @@ import copy
 import hashlib
 import logging
 import math
+import re
 import types
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
@@ -416,12 +417,57 @@ class SignalSchema:
         return subtypes
 
     @staticmethod
+    def _model_matches_custom_type(
+        fr: type[BaseModel], type_name: str, custom_types: dict[str, Any]
+    ) -> bool:
+        """Check that a registered model's field spec equals the spec stored for
+        ``type_name``, including every nested custom type."""
+        if ModelStore.get_name(fr) != type_name:
+            return False
+        reserialized: dict[str, Any] = {}
+        try:
+            SignalSchema._serialize_custom_model(type_name, fr, reserialized)
+            for name, data in reserialized.items():
+                if name not in custom_types:
+                    return False
+                stored = CustomType.deserialize(custom_types[name], name)
+                current = CustomType.deserialize(data, name)
+                if current.fields != stored.fields:
+                    return False
+        except ValidationError:
+            return False
+        return True
+
+    @staticmethod
+    def _custom_type_fingerprint(type_name: str, custom_types: dict[str, Any]) -> str:
+        """Deterministic fingerprint of a stored custom type spec, covering every
+        nested custom type reachable from it."""
+        spec: dict[str, Any] = {}
+        pending = [type_name]
+        while pending:
+            name = pending.pop()
+            if name in spec or name not in custom_types:
+                continue
+            try:
+                ct = CustomType.deserialize(custom_types[name], name)
+            except ValidationError:
+                continue
+            spec[name] = ct.model_dump(exclude={"schema_version"}, exclude_none=True)
+            for field_type in ct.fields.values():
+                pending.extend(re.findall(r"[A-Za-z_]\w*(?:@v\d+)?", field_type))
+        payload = json.dumps(spec, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    @staticmethod
     def _deserialize_custom_type(
         type_name: str, custom_types: dict[str, Any]
     ) -> type | None:
         """Given a type name like MyType@v1 gets a type from ModelStore or recreates
         it based on the information from the custom types dict that includes fields and
-        bases."""
+        bases. A registered model resolves the type only when it matches the stored
+        spec; a same-named model with a different shape is recreated from the spec
+        under a spec-fingerprinted alias, so reads are not shadowed by whichever
+        same-named model happened to register first."""
         model_name, target_version = ModelStore.parse_name_version(type_name)
 
         if type_name in custom_types:
@@ -433,7 +479,15 @@ class SignalSchema:
                 ) from exc
 
             if fr := ModelStore.get(model_name, target_version):
-                return fr
+                if SignalSchema._model_matches_custom_type(fr, type_name, custom_types):
+                    return fr
+                fingerprint = SignalSchema._custom_type_fingerprint(
+                    type_name, custom_types
+                )
+                alias = f"{model_name}_{fingerprint[:10]}"
+                if cached := ModelStore.get(alias, target_version):
+                    return cached
+                type_name = f"{alias}@v{target_version}" if target_version else alias
 
             fields = {
                 field_name: SignalSchema._resolve_type(field_type_str, custom_types)

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1715,6 +1715,25 @@ def test_explode_list_with_null_items(test_session):
     assert chain.to_values("json_expl.email") == [["user@example.com", None]]
 
 
+def test_explode_same_column_name_across_datasets(test_session):
+    dc.read_values(json=[{"a": 1}], session=test_session).explode("json").save(
+        "expl_collide_a"
+    )
+    dc.read_values(json=[{"b": "x"}], session=test_session).explode("json").save(
+        "expl_collide_b"
+    )
+
+    values_b = dc.read_dataset("expl_collide_b", session=test_session).to_values(
+        "json_expl"
+    )
+    values_a = dc.read_dataset("expl_collide_a", session=test_session).to_values(
+        "json_expl"
+    )
+
+    assert values_b[0].b == "x"
+    assert values_a[0].a == 1
+
+
 def test_explode_raises_on_wrong_column_type(test_session):
     chain = dc.read_values(f1=features, session=test_session)
 

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -811,6 +811,65 @@ def test_deserialize_custom_type_bad_schema():
         )
 
 
+def test_deserialize_same_name_different_shape_not_shadowed():
+    def payload(fields):
+        return {
+            "obj": "CollidingGenModel@v1",
+            "_custom_types": {
+                "CollidingGenModel@v1": {
+                    "schema_version": 2,
+                    "name": "CollidingGenModel@v1",
+                    "fields": fields,
+                    "bases": [],
+                }
+            },
+        }
+
+    model_a = SignalSchema.deserialize(payload({"a": "int"})).values["obj"]
+    model_b = SignalSchema.deserialize(payload({"b": "str"})).values["obj"]
+
+    assert set(model_a.model_fields) == {"a"}
+    assert set(model_b.model_fields) == {"b"}
+
+    assert SignalSchema.deserialize(payload({"a": "int"})).values["obj"] is model_a
+    assert SignalSchema.deserialize(payload({"b": "str"})).values["obj"] is model_b
+
+
+def test_deserialize_nested_shape_divergence_not_shadowed():
+    def payload(inner_fields):
+        return {
+            "obj": "CollidingOuterModel@v1",
+            "_custom_types": {
+                "CollidingOuterModel@v1": {
+                    "schema_version": 2,
+                    "name": "CollidingOuterModel@v1",
+                    "fields": {"inner": "CollidingInnerModel@v1"},
+                    "bases": [],
+                },
+                "CollidingInnerModel@v1": {
+                    "schema_version": 2,
+                    "name": "CollidingInnerModel@v1",
+                    "fields": inner_fields,
+                    "bases": [],
+                },
+            },
+        }
+
+    outer_a = SignalSchema.deserialize(payload({"a": "int"})).values["obj"]
+    outer_b = SignalSchema.deserialize(payload({"b": "str"})).values["obj"]
+
+    inner_a = outer_a.model_fields["inner"].annotation
+    inner_b = outer_b.model_fields["inner"].annotation
+    assert set(inner_a.model_fields) == {"a"}
+    assert set(inner_b.model_fields) == {"b"}
+
+
+def test_deserialize_prefers_registered_model_when_spec_matches():
+    schema = SignalSchema({"fr": MyType2}).serialize()
+
+    assert SignalSchema.deserialize(schema).values["fr"] is MyType2
+
+
 def test_select_nested_names():
     schema = SignalSchema.deserialize(
         {


### PR DESCRIPTION
## Problem

`SignalSchema._deserialize_custom_type` resolves custom types by `name@version` alone:

```python
if fr := ModelStore.get(model_name, target_version):
    return fr
```

Since `ModelStore` is process-global and all generated models are `@v1`, two datasets whose inferred models share a name (both `explode()`d from a column named `json`, two parquet files with an `items` list-of-struct column, …) shadow each other: whichever model registers first is used to read every same-named dataset for the rest of the process. Depending on how the shapes overlap that surfaces as a `KeyError` (missing DB column), a Pydantic `ValidationError`, or a silent misread. Repro from #1872:

```python
c1 = dc.read_values(json=[{"a": 1}]).explode("json")
c2 = dc.read_values(json=[{"b": "x"}]).explode("json")
c1.save("e1"); c2.save("e2")
dc.read_dataset("e2").to_values("json_expl")  # works
dc.read_dataset("e1").to_values("json_expl")  # KeyError: 'json_expl__b'
```

## Fix

Following the approach sketched in the issue:

- A registered model resolves a custom type only when its field spec matches the spec stored in the dataset schema. The check reserializes the registered model with the existing `_serialize_custom_model` machinery and compares `fields` per custom type, so a divergence in a *nested* model (identical top-level field strings, different `Inner@v1` shapes) is caught too.
- On mismatch, the model is recreated from the stored spec under a spec-fingerprinted alias (`{name}_{fingerprint[:10]}`, the same shape `to_partial` uses for partials) instead of clobbering the registered model's name in `ModelStore`. Repeated reads of the same dataset hit the alias cache and reuse the recreated class.
- When there is no registered model, behavior is unchanged (recreate under the stored name and register).

The fingerprint covers the transitive closure of the type's spec (fields, bases, hidden fields of every reachable custom type), so two colliding specs that differ only in a nested type or base still get distinct aliases.

## Testing

- `test_deserialize_same_name_different_shape_not_shadowed` — the cross-dataset collision, plus re-read identity (same class object on repeated deserialization of both specs)
- `test_deserialize_nested_shape_divergence_not_shadowed` — identical top-level specs, diverging nested model
- `test_deserialize_prefers_registered_model_when_spec_matches` — round-trip still returns the registered class itself, not a recreation
- `test_explode_same_column_name_across_datasets` — the issue's end-to-end repro (`explode` → `save` → `read_dataset` both ways)

All four were run against unmodified `main` first: the three collision tests fail there (the e2e test with `KeyError: 'json_expl__a'`), and the registered-model test passes on both, confirming no regression of round-trip identity. Full `tests/unit/lib/test_signal_schema.py` (120) and `tests/unit/lib/test_datachain.py` (349) pass; `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

Fixes #1872