### PR TITLE
fix: continue after plugin loading failures

### DIFF
--- a/src/datachain/plugins.py
+++ b/src/datachain/plugins.py
@@ -5,7 +5,10 @@ per process. This enables external packages (e.g., Studio) to register
 their callables with the serializer registry without explicit imports.
 """
 
+import logging
 from importlib import metadata as importlib_metadata
+
+logger = logging.getLogger("datachain")
 
 _plugins_loaded = False
 
@@ -18,7 +21,16 @@ def ensure_plugins_loaded() -> None:
     # Compatible across importlib.metadata versions
     eps_obj = importlib_metadata.entry_points()
     for ep in eps_obj.select(group="datachain.callables"):
-        func = ep.load()
-        func()
+        try:
+            func = ep.load()
+            func()
+        except Exception as exc:  # noqa: BLE001
+            distribution = getattr(getattr(ep, "dist", None), "name", "unknown")
+            logger.warning(
+                "Failed to initialize DataChain plugin %r from distribution %r: %s",
+                ep.name,
+                distribution,
+                exc,
+            )
 
     _plugins_loaded = True

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -1,0 +1,43 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from datachain import plugins
+
+
+@pytest.mark.parametrize("failure_stage", ["load", "initialize"])
+def test_plugin_failure_warns_and_continues(mocker, caplog, failure_stage):
+    error = RuntimeError("broken plugin")
+    broken_func = mocker.Mock(
+        side_effect=error if failure_stage == "initialize" else None
+    )
+    broken_load = mocker.Mock(
+        side_effect=error if failure_stage == "load" else None,
+        return_value=broken_func,
+    )
+    working_func = mocker.Mock()
+    entry_points = [
+        SimpleNamespace(
+            name="broken", dist=SimpleNamespace(name="broken-dist"), load=broken_load
+        ),
+        SimpleNamespace(
+            name="working",
+            dist=SimpleNamespace(name="working-dist"),
+            load=mocker.Mock(return_value=working_func),
+        ),
+    ]
+    mocker.patch.object(
+        plugins.importlib_metadata,
+        "entry_points",
+        return_value=SimpleNamespace(select=lambda **kwargs: entry_points),
+    )
+    mocker.patch.object(plugins, "_plugins_loaded", False)
+
+    with caplog.at_level(logging.WARNING, logger="datachain"):
+        plugins.ensure_plugins_loaded()
+
+    working_func.assert_called_once_with()
+    assert "broken" in caplog.text
+    assert "broken-dist" in caplog.text
+    assert "broken plugin" in caplog.text


### PR DESCRIPTION
## Summary
- catch failures while loading or initializing individual `datachain.callables` entry points
- warn with the entry-point name, owning distribution, and original error
- continue initializing later plugins so one stale installation cannot disable DataChain

## Root cause
`ensure_plugins_loaded()` invoked every entry point without an exception boundary. An orphaned or broken third-party distribution therefore aborted serializer setup and surfaced through unrelated library and CLI operations.

## Tests
- added parameterized regressions for failures from both `EntryPoint.load()` and the loaded callable
- verified a later valid plugin still initializes and the warning identifies the broken entry point, distribution, and error
- `python -m pytest tests/unit/test_plugins.py tests/unit/test_data_storage.py -q` (18 passed)
- `pre-commit run --files src/datachain/plugins.py tests/unit/test_plugins.py`
- `python -m mypy src/datachain/plugins.py tests/unit/test_plugins.py --ignore-missing-imports`

Closes #1904