### PR TITLE
test: harden the collection-hydration coverage

### DIFF
--- a/tests/func/test_udf.py
+++ b/tests/func/test_udf.py
@@ -1178,6 +1178,119 @@ def test_agg_list_file_and_map_count(tmp_dir, test_session):
     assert rows == [(len(expected_files),)]
 
 
+def test_agg_reads_files_from_every_batch_row(test_session, tmp_path):
+    class BatchedFileHolder(dc.DataModel):
+        files: list[File]
+
+    (tmp_path / "short.txt").write_text("ab")
+    (tmp_path / "longer.txt").write_text("cdef")
+
+    def wrap_file(file: File) -> BatchedFileHolder:
+        return BatchedFileHolder(files=[file])
+
+    # the parameter names the signal; the list type is what makes it batched
+    def total_size(holder: list[BatchedFileHolder]) -> Iterator[int]:
+        yield sum(len(h.files[0].read()) for h in holder)
+
+    chain = (
+        dc.read_storage(tmp_path.as_uri(), session=test_session)
+        .map(holder=wrap_file)
+        .agg(total=total_size)
+    )
+
+    assert chain.to_values("total") == [len("ab") + len("cdef")]
+
+
+def test_map_reads_file_from_model_param(test_session, tmp_path):
+    class HeldFileHolder(dc.DataModel):
+        files: list[File]
+
+    (tmp_path / "held.txt").write_text("held")
+
+    def wrap_file(file: File) -> HeldFileHolder:
+        return HeldFileHolder(files=[file])
+
+    def read_from_holder(holder: HeldFileHolder) -> str:
+        return holder.files[0].read().decode()
+
+    chain = (
+        dc.read_storage(tmp_path.as_uri(), session=test_session)
+        .map(holder=wrap_file)
+        .map(content=read_from_holder)
+    )
+
+    assert chain.to_values("content") == ["held"]
+
+
+def test_map_reads_file_from_setup_value(test_session, tmp_path):
+    (tmp_path / "reference.txt").write_text("reference")
+    uri = tmp_path.as_uri()
+
+    chain = (
+        dc.read_storage(uri, session=test_session)
+        .setup(ref=lambda: File(path="reference.txt", source=uri))
+        .map(size=lambda ref: len(ref.read()), output=int)
+    )
+
+    assert chain.to_values("size") == [len("reference")]
+
+
+@pytest.mark.xdist_group(name="tmpfile")
+def test_map_reads_file_from_collection_in_child_process(
+    test_session_tmpfile, tmp_path
+):
+    class ParallelFileHolder(dc.DataModel):
+        files: list[File]
+
+    # a subdirectory, so listing does not pick up the session's own database
+    data = tmp_path / "data"
+    data.mkdir()
+    # more than one row: parallelism is disabled outright at a single row
+    for name in ("first", "second", "third"):
+        (data / f"{name}.txt").write_text(name)
+
+    def wrap_file(file: File) -> ParallelFileHolder:
+        return ParallelFileHolder(files=[file])
+
+    def read_first(files: list[File]) -> str:
+        return f"{os.getpid()}:{files[0].read().decode()}"
+
+    chain = (
+        dc.read_storage(data.as_uri(), session=test_session_tmpfile)
+        .settings(parallel=2)
+        .map(holder=wrap_file)
+        .map(content=read_first, params=["holder.files"])
+    )
+
+    # workers return in no guaranteed order
+    results = [value.split(":", 1) for value in chain.to_values("content")]
+    assert sorted(content for _, content in results) == ["first", "second", "third"]
+    assert os.getpid() not in {int(pid) for pid, _ in results}
+
+
+def test_map_reads_file_from_collection_param(test_session, tmp_path):
+    class NestedFileHolder(dc.DataModel):
+        files: list[File]
+
+    path = tmp_path / "nested.txt"
+    path.write_text("contents")
+
+    # two distinct objects, so every member has to be visited, not just the first
+    def wrap_file(file: File) -> NestedFileHolder:
+        return NestedFileHolder(files=[file, file.model_copy()])
+
+    def read_all(files: list[File]) -> str:
+        return "".join(f.read().decode() for f in files)
+
+    chain = (
+        dc.read_storage(tmp_path.as_uri(), session=test_session)
+        .map(holder=wrap_file)
+        .map(content=read_all, params=["holder.files"])
+    )
+
+    assert chain.to_values("content") == ["contentscontents"]
+
+
 def test_agg_list_file_persist_and_read(tmp_dir, test_session):
     names = ["a.txt", "b.txt", "c.txt"]
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -911,8 +911,8 @@ def test_map(test_session):
         assert x.my_name == test_fr.my_name
 
 
-def test_map_converts_nested_collection_items_to_models(test_session):
-    class ModelCollection(DataModel):
+def test_map_hydrates_models_in_nested_list_param(test_session):
+    class ListCollection(DataModel):
         items: list[MyFr]
 
     def get_count(items: list[MyFr]) -> int:
@@ -920,19 +920,15 @@ def test_map_converts_nested_collection_items_to_models(test_session):
         return items[0].count
 
     chain = dc.read_values(
-        collection=[ModelCollection(items=[MyFr(nnn="item", count=2)])],
+        collection=[ListCollection(items=[MyFr(nnn="item", count=2)])],
         session=test_session,
-    ).map(
-        get_count,
-        params=["collection.items"],
-        output={"count": int},
-    )
+    ).map(count=get_count, params=["collection.items"])
 
     assert chain.to_values("count") == [2]
 
 
 def test_map_hydrates_models_in_optional_dict_param(test_session):
-    class ModelCollection(DataModel):
+    class OptionalDictCollection(DataModel):
         lookup: dict[str, MyFr] | None
 
     def get_count(lookup: dict[str, MyFr] | None) -> int:
@@ -940,91 +936,78 @@ def test_map_hydrates_models_in_optional_dict_param(test_session):
         return lookup["item"].count
 
     chain = dc.read_values(
-        collection=[ModelCollection(lookup={"item": MyFr(nnn="item", count=3)})],
+        collection=[OptionalDictCollection(lookup={"item": MyFr(nnn="item", count=3)})],
         session=test_session,
-    ).map(
-        get_count,
-        params=["collection.lookup"],
-        output={"count": int},
-    )
+    ).map(count=get_count, params=["collection.lookup"])
 
     assert chain.to_values("count") == [3]
 
 
-def test_map_hydrates_models_in_tuple_param(test_session):
+def test_map_hydrates_models_in_variadic_tuple_param(test_session):
     class TupleCollection(DataModel):
         items: tuple[MyFr, ...]
 
-    def get_count(items: tuple[MyFr, ...]) -> int:
+    def total(items: tuple[MyFr, ...]) -> int:
+        assert isinstance(items, tuple)
+        assert all(isinstance(item, MyFr) for item in items)
+        return sum(item.count for item in items)
+
+    chain = dc.read_values(
+        collection=[
+            TupleCollection(items=(MyFr(nnn="a", count=4), MyFr(nnn="b", count=5)))
+        ],
+        session=test_session,
+    ).map(count=total, params=["collection.items"])
+
+    assert chain.to_values("count") == [9]
+
+
+def test_map_preserves_json_looking_key_for_optional_str_key(test_session):
+    class OptionalStringKeyCollection(DataModel):
+        lookup: dict[str | None, int]
+
+    # "null" is valid JSON, so a decoded key would come back as None
+    def first_key(lookup: dict[str | None, int]) -> str | None:
+        (key,) = lookup
+        return key
+
+    chain = dc.read_values(
+        collection=[OptionalStringKeyCollection(lookup={"null": 5})],
+        session=test_session,
+    ).map(key=first_key, params=["collection.lookup"])
+
+    assert chain.to_values("key") == ["null"]
+
+
+def test_map_hydrates_models_in_top_level_list_param(test_session):
+    def get_count(items: list[MyFr]) -> int:
         assert isinstance(items[0], MyFr)
         return items[0].count
 
     chain = dc.read_values(
-        collection=[TupleCollection(items=(MyFr(nnn="item", count=4),))],
+        items=[[MyFr(nnn="item", count=7)]],
         session=test_session,
-    ).map(
-        get_count,
-        params=["collection.items"],
-        output={"count": int},
-    )
+    ).map(count=get_count)
 
-    assert chain.to_values("count") == [4]
+    assert chain.to_values("count") == [7]
 
 
-def test_map_keeps_string_dict_keys_in_union(test_session):
-    class UnionKeyCollection(DataModel):
-        lookup: dict[str | None, int]
+def test_gen_hydrates_models_in_nested_list_param(test_session):
+    class GenListCollection(DataModel):
+        items: list[MyFr]
 
-    def total(lookup: dict[str | None, int]) -> int:
-        return sum(lookup.values())
+    def spread(items: list[MyFr]) -> Iterator[int]:
+        assert isinstance(items[0], MyFr)
+        yield from (item.count for item in items)
 
     chain = dc.read_values(
-        collection=[UnionKeyCollection(lookup={"item": 5})],
+        collection=[
+            GenListCollection(items=[MyFr(nnn="a", count=1), MyFr(nnn="b", count=2)])
+        ],
         session=test_session,
-    ).map(
-        total,
-        params=["collection.lookup"],
-        output={"count": int},
-    )
+    ).gen(count=spread, params=["collection.items"])
 
-    assert chain.to_values("count") == [5]
-
-
-def test_map_reads_file_from_setup_value(test_session, tmp_path):
-    (tmp_path / "reference.txt").write_text("reference")
-    uri = tmp_path.as_uri()
-
-    chain = (
-        dc.read_storage(uri, session=test_session)
-        .setup(ref=lambda: File(path="reference.txt", source=uri))
-        .map(size=lambda ref: len(ref.read()), output=int)
-    )
-
-    assert chain.to_values("size") == [len("reference")]
-
-
-def test_map_reads_file_in_nested_collection(test_session, tmp_path):
-    class FileCollection(DataModel):
-        files: list[File]
-
-    path = tmp_path / "nested.txt"
-    path.write_text("contents")
-
-    chain = (
-        dc.read_storage(tmp_path.as_uri(), session=test_session)
-        .map(
-            collection=lambda file: FileCollection(files=[file]),
-            params=["file"],
-            output={"collection": FileCollection},
-        )
-        .map(
-            content=lambda files: files[0].read().decode(),
-            params=["collection.files"],
-            output={"content": str},
-        )
-    )
-
-    assert chain.to_values("content") == ["contents"]
+    assert sorted(chain.to_values("count")) == [1, 2]
 
 
 def test_map_multiple_signals(test_session):

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Literal
+from typing import Dict, Literal  # noqa: UP035
 
 import pytest
 
@@ -16,11 +16,23 @@ from tests.unit.lib.test_utils import MyModel
         (Literal["text"], String),
         (dict[str, int], JSON),
         (Mapping[str, int], JSON),
+        # a zero-argument mapping alias still needs a column
+        (Dict, JSON),  # noqa: UP006
         (str | None, String),
         (dict | list[dict], JSON),
     ),
+    ids=[
+        "str",
+        "String",
+        "Literal",
+        "dict",
+        "Mapping",
+        "bare-typing-Dict",
+        "optional-str",
+        "dict-or-list-of-dict",
+    ],
 )
-def test_convert_type_to_datachain(typ, expected):
+def test_python_to_sql_conversions(typ, expected):
     assert python_to_sql(typ) == expected
 
 

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1,5 +1,6 @@
 import json
 import pickle
+from collections import UserDict, UserList
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import datetime
 from typing import (
@@ -20,6 +21,7 @@ from typing_extensions import TypedDict
 
 from datachain import Column, DataModel, Sys, func
 from datachain.lib.convert.flatten import flatten
+from datachain.lib.data_model import is_mapping_annotation
 from datachain.lib.file import File, TextFile
 from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import (
@@ -65,7 +67,7 @@ _T = TypeVar("_T")
 
 
 class GenericTypedRow(TypedDict, Generic[_T]):
-    x: int
+    x: _T
 
 
 class MyType1(DataModel):
@@ -1009,20 +1011,6 @@ def test_row_to_features_dict_of_models(test_session):
     assert lookup["second"].deep.aa == 2
 
 
-def test_row_to_features_optional_collection(test_session):
-    schema = SignalSchema({"items": list[MyType1] | None})
-
-    features_none = schema.row_to_features((None,), test_session.catalog)
-    assert features_none == [None]
-
-    row = ([{"aa": 3, "bb": "z"}],)
-    features = schema.row_to_features(row, test_session.catalog)
-    assert len(features) == 1
-    items = features[0]
-    assert isinstance(items, list)
-    assert isinstance(items[0], MyType1)
-
-
 def test_row_to_features_sets_stream_in_model_collection(test_session):
     class FileCollection(DataModel):
         files: list[File]
@@ -1046,16 +1034,29 @@ def test_row_to_objs_preserves_plain_collection():
 @pytest.mark.parametrize(
     "key_type,raw,expected",
     [
-        # Keys that can be ordinary strings must not be JSON-decoded.
-        (str, {"foo": 1}, {"foo": 1}),
-        (Optional[str], {"foo": 1}, {"foo": 1}),
-        (Any, {"foo": 1}, {"foo": 1}),
+        # These key types are left undecoded even when the key is valid JSON.
+        (str, {"null": 1}, {"null": 1}),
+        (Optional[str], {"null": 1}, {"null": 1}),
+        (Any, {"null": 1}, {"null": 1}),
         # Keys that cannot be strings are decoded back to the declared type.
         (int, {"1": 2}, {1: 2}),
-        (Optional[int], {"1": 2}, {1: 2}),
+        # the contrast with optional-str, where "null" deliberately stays a string
+        (Optional[int], {"null": 2}, {None: 2}),
+        # both orders: deciding on either end alone would decode these
+        (int | str, {"null": 1}, {"null": 1}),
+        (str | int, {"null": 1}, {"null": 1}),
+    ],
+    ids=[
+        "str",
+        "optional-str",
+        "any",
+        "int",
+        "optional-int-null",
+        "int-or-str",
+        "str-or-int",
     ],
 )
-def test_row_to_objs_dict_key_decoding(key_type, raw, expected):
+def test_row_to_objs_dict_key_decoding_policy(key_type, raw, expected):
     (converted,) = SignalSchema({"m": dict[key_type, int]}).row_to_objs((raw,))
 
     assert converted == expected
@@ -1064,13 +1065,12 @@ def test_row_to_objs_dict_key_decoding(key_type, raw, expected):
 def test_row_to_features_does_not_decode_string_keys(test_session):
     schema = SignalSchema({"m": dict[Optional[str], int]})
 
-    (converted,) = schema.row_to_features(({"foo": 1},), test_session.catalog)
+    (converted,) = schema.row_to_features(({"null": 1},), test_session.catalog)
 
-    assert converted == {"foo": 1}
+    assert converted == {"null": 1}
 
 
-def test_row_to_objs_restores_tuple_shape_without_conversion():
-    # Nothing to convert, but the declared tuple must not arrive as a list.
+def test_row_to_objs_restores_variadic_tuple_shape():
     (converted,) = SignalSchema({"t": tuple[int, ...]}).row_to_objs(([1, 2],))
 
     assert converted == (1, 2)
@@ -1081,49 +1081,69 @@ def test_row_to_objs_converts_fixed_tuple_positionally():
 
     (converted,) = SignalSchema({"t": tuple[int, File]}).row_to_objs((raw,))
 
+    assert isinstance(converted, tuple)
     assert converted[0] == 1
     assert isinstance(converted[1], File)
+    assert converted[1].path == "a.txt"
+
+
+def _make_two_model_items():
+    return [{"aa": 1, "bb": "b"}, {"aa": 2, "bb": "c"}]
+
+
+def _make_two_model_entries():
+    return {"x": {"aa": 1, "bb": "b"}, "y": {"aa": 2, "bb": "c"}}
+
+
+def _make_two_user_dict_entries():
+    # the annotation already selects the mapping branch; a non-dict mapping is
+    # what proves the runtime guard accepts any Mapping
+    return UserDict(_make_two_model_entries())
 
 
 @pytest.mark.parametrize(
-    "raw,expected",
+    "annotation,make_raw",
     [
-        # A key type that admits plain strings is never decoded, so a key that
-        # happens to look like JSON stays a string.
-        ({"foo": 1}, {"foo": 1}),
-        ({"null": 1}, {"null": 1}),
+        (Collection[MyType1], _make_two_model_items),
+        (Iterable[MyType1], _make_two_model_items),
+        (Sequence[MyType1], _make_two_model_items),
+        (list[MyType1], _make_two_model_items),
+        (dict[str, MyType1], _make_two_model_entries),
+        (Mapping[str, MyType1], _make_two_user_dict_entries),
     ],
+    ids=["Collection", "Iterable", "Sequence", "list", "dict", "Mapping"],
 )
-def test_row_to_objs_leaves_string_admitting_keys_alone(raw, expected):
-    (converted,) = SignalSchema({"m": dict[Optional[str], int]}).row_to_objs((raw,))
-
-    assert converted == expected
-
-
-@pytest.mark.parametrize(
-    "annotation",
-    [Collection[MyType1], Iterable[MyType1], Sequence[MyType1], list[MyType1]],
-)
-def test_both_readers_hydrate_the_same_collections(annotation, test_session):
-    raw = [{"aa": 1, "bb": "b"}]
+def test_row_readers_hydrate_collection_members(annotation, make_raw, test_session):
     schema = SignalSchema({"x": annotation})
 
-    (from_objs,) = schema.row_to_objs((raw,))
-    (from_features,) = schema.row_to_features((raw,), test_session.catalog)
+    # a fresh value per reader, so neither can hydrate in place for the other
+    (from_objs,) = schema.row_to_objs((make_raw(),))
+    (from_features,) = schema.row_to_features((make_raw(),), test_session.catalog)
 
-    assert isinstance(next(iter(from_objs)), MyType1)
-    assert isinstance(next(iter(from_features)), MyType1)
+    for converted in (from_objs, from_features):
+        if is_mapping_annotation(annotation):
+            assert isinstance(converted, Mapping)
+            assert {k: (type(v), v.aa) for k, v in converted.items()} == {
+                "x": (MyType1, 1),
+                "y": (MyType1, 2),
+            }
+        else:
+            assert [(type(m), m.aa) for m in converted] == [(MyType1, 1), (MyType1, 2)]
 
 
 def test_row_to_objs_keeps_sequence_as_a_list():
-    # Sequence is satisfiable by a tuple but is not one, so a stored list must
-    # come back as a list, unlike a declared tuple.
     (converted,) = SignalSchema({"s": Sequence[MyType1]}).row_to_objs(
         ([{"aa": 1, "bb": "b"}],)
     )
 
     assert isinstance(converted, list)
     assert isinstance(converted[0], MyType1)
+
+
+def test_row_to_objs_keeps_raw_key_when_json_decode_fails():
+    (converted,) = SignalSchema({"m": dict[int, int]}).row_to_objs(({"foo": 1},))
+
+    assert converted == {"foo": 1}
 
 
 def test_row_to_objs_decodes_tuple_keys():
@@ -1134,23 +1154,36 @@ def test_row_to_objs_decodes_tuple_keys():
     assert converted == {("a", 1): 2}
 
 
-def test_row_to_objs_hydrates_tuple_collection():
-    raw = [{"aa": 1, "bb": "b"}]
+def test_set_file_streams_rereads_fields_after_a_forward_ref_resolves(test_session):
+    class Outer(BaseModel):
+        child: "OuterInner | None" = None
 
-    (converted,) = SignalSchema({"items": tuple[MyType1, ...]}).row_to_objs((raw,))
+    # model_construct skips validation, so an incomplete model can be traversed
+    SignalSchema({"s": str}, setup={"s": lambda: None}).set_file_streams(
+        [Outer.model_construct()], test_session.catalog
+    )
 
-    assert isinstance(converted, tuple)
-    assert isinstance(converted[0], MyType1)
+    class OuterInner(BaseModel):
+        file: File
+
+    Outer.model_rebuild(_types_namespace={"OuterInner": OuterInner, "File": File})
+    file = File(path="resolved.txt")
+
+    SignalSchema({"s": str}, setup={"s": lambda: None}).set_file_streams(
+        [Outer(child=OuterInner(file=file))], test_session.catalog
+    )
+
+    assert file._catalog is test_session.catalog
 
 
-def test_file_bearing_fields_does_not_pin_recursive_models():
+def test_set_file_streams_does_not_pin_recursive_model_classes(test_session):
     import gc
     import weakref
 
     refs = []
     for i in range(5):
         # plain BaseModel: a DataModel would be pinned by ModelStore, not the cache
-        node = type(
+        node_cls = type(
             f"Node{i}",
             (BaseModel,),
             {
@@ -1158,25 +1191,31 @@ def test_file_bearing_fields_does_not_pin_recursive_models():
                 "child": None,
             },
         )
-        node.model_rebuild(_types_namespace={f"Node{i}": node, "File": File})
-        # names only, so the cached value cannot refer back to the class
-        assert SignalSchema._file_bearing_fields(node) == ("file", "child")
-        refs.append(weakref.ref(node))
-        del node
+        node_cls.model_rebuild(_types_namespace={f"Node{i}": node_cls, "File": File})
+        file = File(path=f"{i}.txt")
+        nested = File(path=f"{i}-nested.txt")
+        # a self-referential model cannot be a signal type, so go via setup
+        schema = SignalSchema({"s": str}, setup={"s": lambda: None})
+        schema.set_file_streams(
+            [node_cls(file=file, child=node_cls(file=nested))], test_session.catalog
+        )
+        assert file._catalog is test_session.catalog
+        assert nested._catalog is test_session.catalog
+        refs.append(weakref.ref(node_cls))
+        del node_cls
 
     gc.collect()
 
     assert [r() for r in refs] == [None] * 5
 
 
-def test_set_file_streams_with_generic_typed_dict_field(test_session):
+def test_set_file_streams_handles_generic_typed_dict_field(test_session):
     class Bundle(DataModel):
         payload: GenericTypedRow[int]
         file: File
 
     file = File(path="a.txt")
 
-    # Scanning for File fields must not trip over a field that rejects issubclass.
     SignalSchema({"b": Bundle}).set_file_streams(
         [Bundle(payload={"x": 1}, file=file)], test_session.catalog
     )
@@ -1202,48 +1241,50 @@ def test_set_file_streams_handles_abstract_sequence(test_session):
     class SeqHolder(DataModel):
         files: Sequence[File]
 
-    file = File(path="nested.txt")
+    files = [File(path="a.txt"), File(path="b.txt")]
+    holder = SeqHolder(files=UserList(files))
+    # the holder keeps a UserList, which is what makes this an abstract case
+    assert isinstance(holder.files, UserList)
 
-    SignalSchema({"h": SeqHolder}).set_file_streams(
-        [SeqHolder(files=[file])], test_session.catalog
-    )
+    SignalSchema({"h": SeqHolder}).set_file_streams([holder], test_session.catalog)
 
-    assert file._catalog is test_session.catalog
+    assert all(f._catalog is test_session.catalog for f in files)
 
 
 def test_set_file_streams_handles_abstract_mapping(test_session):
     class MapHolder(DataModel):
         files: Mapping[str, File]
 
-    file = File(path="nested.txt")
+    files = [File(path="a.txt"), File(path="b.txt")]
+    # validation would coerce a UserDict to a plain dict, hiding the ABC branch
+    holder = MapHolder.model_construct(files=UserDict({"a": files[0], "b": files[1]}))
 
-    SignalSchema({"h": MapHolder}).set_file_streams(
-        [MapHolder(files={"k": file})], test_session.catalog
-    )
+    SignalSchema({"h": MapHolder}).set_file_streams([holder], test_session.catalog)
 
-    assert file._catalog is test_session.catalog
+    assert all(f._catalog is test_session.catalog for f in files)
 
 
-def test_set_file_streams_visits_a_shared_object_once(test_session):
+def test_set_file_streams_visits_a_shared_object_once(test_session, monkeypatch):
     class Holder(DataModel):
         left: File
         right: File
 
     file = File(path="shared.txt")
-    calls = []
+    streamed = []
     original = File._set_stream
-    File._set_stream = lambda self, *a, **k: (
-        calls.append(self),
-        original(self, *a, **k),
-    )[1]
-    try:
-        SignalSchema({"h": Holder}).set_file_streams(
-            [Holder(left=file, right=file)], test_session.catalog
-        )
-    finally:
-        File._set_stream = original
 
-    assert calls == [file]
+    def record(self, *args, **kwargs):
+        streamed.append(self)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(File, "_set_stream", record)
+
+    SignalSchema({"h": Holder}).set_file_streams(
+        [Holder(left=file, right=file)], test_session.catalog
+    )
+
+    assert len(streamed) == 1
+    assert streamed[0] is file
     assert file._catalog is test_session.catalog
 
 
@@ -1260,7 +1301,7 @@ def test_set_file_streams_visits_mapping_keys(test_session):
     assert key._catalog is test_session.catalog
 
 
-def test_set_file_streams_skips_params_that_cannot_hold_a_file(test_session):
+def test_set_file_streams_reaches_a_file_after_a_plain_model(test_session):
     class Plain(DataModel):
         name: str
 
@@ -1273,31 +1314,21 @@ def test_set_file_streams_skips_params_that_cannot_hold_a_file(test_session):
 
 
 @pytest.mark.parametrize(
-    "union_type,union_name",
-    [
-        (Union[list[MyType1], None], "Union[list[MyType1], None]"),
-        (list[MyType1] | None, "list[MyType1] | None"),
-    ],
+    "union_type",
+    [Union[list[MyType1], None], list[MyType1] | None],
     ids=["old-style-union", "new-style-union"],
 )
-def test_row_to_features_union_types(test_session, union_type, union_name):
-    """Test that both old-style Union[X, None] and new-style X | None work correctly."""
+def test_row_to_features_optional_collection(test_session, union_type):
     schema = SignalSchema({"items": union_type})
 
-    # Test None case
-    features_none = schema.row_to_features((None,), test_session.catalog)
-    assert features_none == [None], f"Failed for {union_name} with None value"
+    assert schema.row_to_features((None,), test_session.catalog) == [None]
 
-    # Test non-None case
-    row = ([{"aa": 5, "bb": "test"}],)
-    features = schema.row_to_features(row, test_session.catalog)
-    assert len(features) == 1, f"Failed for {union_name}"
-    items = features[0]
-    assert isinstance(items, list), f"Expected list for {union_name}, got {type(items)}"
-    assert len(items) == 1, f"Expected 1 item for {union_name}"
-    assert isinstance(items[0], MyType1), f"Expected MyType1 instance for {union_name}"
-    assert items[0].aa == 5, f"Wrong value for {union_name}"
-    assert items[0].bb == "test", f"Wrong value for {union_name}"
+    (items,) = schema.row_to_features(
+        ([{"aa": 5, "bb": "test"}],), test_session.catalog
+    )
+
+    assert isinstance(items, list)
+    assert [(type(i), i.aa, i.bb) for i in items] == [(MyType1, 5, "test")]
 
 
 def test_get_signals_subclass(nested_file_schema):

--- a/tests/unit/test_data_model.py
+++ b/tests/unit/test_data_model.py
@@ -1,5 +1,5 @@
 import copy
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from typing import Dict, Generic, List, TypeVar  # noqa: UP035
 
 import pytest
@@ -7,14 +7,12 @@ import pytest
 # typing.TypedDict cannot be combined with Generic on Python 3.10
 from typing_extensions import TypedDict
 
-from datachain.lib.convert.python_to_sql import python_to_sql
 from datachain.lib.data_model import (
     DataModel,
     compute_model_fingerprint,
     is_chain_type,
 )
 from datachain.lib.model_store import ModelStore
-from datachain.sql.types import JSON
 
 
 @pytest.fixture(autouse=True)
@@ -98,30 +96,32 @@ def test_is_chain_type_handles_generics_that_reject_issubclass():
     T = TypeVar("T")
 
     class GenericRow(TypedDict, Generic[T]):
-        x: int
+        x: T
 
-    # TypedDicts raise on issubclass; validation must answer, not crash.
     assert is_chain_type(GenericRow[int]) is False
 
 
 @pytest.mark.parametrize(
     "annotation",
     [
-        # Abstract origins serialize as a bare "Sequence"/"Mapping", losing their
-        # args, so a saved signal would not survive a reload.
+        # Abstract origins serialize as their bare origin name, losing their args,
+        # so a saved signal would not survive a reload.
         Sequence[int],
         Mapping[str, int],
-        # Bare aliases have no args for the SQL layer to work from.
-        List,  # noqa: UP006
-        Dict,  # noqa: UP006
-        tuple,
+        Collection[int],
+        Iterable[int],
     ],
+    ids=["Sequence", "Mapping", "Collection", "Iterable"],
 )
-def test_is_chain_type_rejects_types_that_cannot_round_trip(annotation):
+def test_is_chain_type_rejects_abstract_collection_roots(annotation):
     assert is_chain_type(annotation) is False
 
 
-@pytest.mark.parametrize("annotation", [list[int], dict[str, int], list[list[int]]])
+@pytest.mark.parametrize(
+    "annotation",
+    [list[int], dict[str, int], list[list[int]]],
+    ids=["list", "dict", "nested-list"],
+)
 def test_is_chain_type_accepts_serializable_collections(annotation):
     assert is_chain_type(annotation) is True
 
@@ -129,24 +129,59 @@ def test_is_chain_type_accepts_serializable_collections(annotation):
 @pytest.mark.parametrize(
     "annotation",
     [
-        # Wrong arity is silently truncated by `type_to_str`, e.g. `dict[str]`
-        # would be written back out as `dict[str, Any]`.
+        # `type_to_str` normalises a wrong arity rather than refusing it, so
+        # `dict[str]` would be written back out as `dict[str, Any]`.
         list[int, str],  # type: ignore[misc]
         dict[str],  # type: ignore[misc]
         dict[str, int, float],  # type: ignore[misc]
         # `python_to_sql` mis-types tuples, so they are not valid root signals.
         tuple[int, ...],
         tuple[int, str],
-        # Ellipsis must not be normalised away before the arity is checked.
+        # `set` has no column type, and rejection must hold through nesting
+        set[int],
+        list[set[int]],
+        # both arguments are validated, not just one
+        dict[str, set[int]],
+        dict[set[int], int],
+        # Ellipsis counts toward arity during validation; it must not be
+        # normalised away first.
         list[int, ...],  # type: ignore[misc]
         dict[str, int, ...],  # type: ignore[misc]
         list[..., int],  # type: ignore[misc]
     ],
+    ids=[
+        "list-two-args",
+        "dict-one-arg",
+        "dict-three-args",
+        "variadic-tuple",
+        "fixed-tuple",
+        "set",
+        "nested-set",
+        "set-as-dict-value",
+        "set-as-dict-key",
+        "list-ellipsis",
+        "dict-ellipsis",
+        "list-leading-ellipsis",
+    ],
 )
-def test_is_chain_type_rejects_malformed_or_mistyped_collections(annotation):
+def test_is_chain_type_rejects_unsupported_or_malformed_collection_annotations(
+    annotation,
+):
     assert is_chain_type(annotation) is False
 
 
-def test_python_to_sql_still_accepts_bare_dict_aliases():
-    # A `payload: Dict` field must keep mapping to a JSON column.
-    assert python_to_sql(Dict) is JSON  # noqa: UP006
+def test_is_chain_type_accepts_bare_dict():
+    assert is_chain_type(dict) is True
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        List,  # noqa: UP006
+        Dict,  # noqa: UP006
+        tuple,
+    ],
+    ids=["typing-List", "typing-Dict", "tuple"],
+)
+def test_is_chain_type_rejects_unsupported_bare_collection_roots(annotation):
+    assert is_chain_type(annotation) is False


### PR DESCRIPTION
Follow-up to #1867 and #1911. **Tests only** — `git diff --name-only origin/main...HEAD -- src/` is empty.

## Summary

- Filesystem-driving tests moved to `tests/func/test_udf.py`; `tests/unit/lib/test_datachain.py` uses no `tmp_path`, as before #1867.
- The cache test no longer calls `_file_bearing_fields` directly; it asserts through the public `set_file_streams`. Tests still inspect `File._catalog` and one patches `File._set_stream`, since no public surface exposes stream attachment.
- `params=`/`output=` removed wherever a typed signature supplies them. What remains cannot be inferred: dotted paths, and one unannotated lambda.
- Comments follow `AGENT.md` — names carry intent; what remains states a constraint rather than restating a name.
- Duplicated and inert tests removed or merged.

## Coverage added

| shape | why it matters |
|---|---|
| top-level `list[Model]` param | nesting was never the discriminator |
| whole model holding `list[File]` | the ordinary shape, and the more damaging half of the bug |
| `.gen()` / `Generator` | shares `_prepare_row` |
| `.agg()` across two batch rows | `slice(is_batch=True)` stores the *unwrapped* type |
| a collection read in a child process | the collection path had never run off the main process |
| abstract `Mapping` hydration | previously covered only for sequence spellings |
| `int \| str` and `str \| int` keys | one string arm must disable decoding, from either end |
| `set` rejection, incl. `list[set[int]]` | a known transient-acceptance trap |
| `dict[str, set[int]]`, `dict[set[int], int]` | both arguments are validated, not one |
| forward-reference cache guard | reachable via `model_construct()` |
| malformed dict key | pins the retain-rather-than-raise policy |
| bare `typing.Dict` → `JSON` | the only guard on #1911's arity fix |
| bare-root acceptance and rejection | split into `dict` accepted and `List`/`Dict`/`tuple` rejected; bare `list` is unwritable (#1923) and so not asserted |

## Validation

`tests/unit`: 3095 passed, 15 skipped, 15 xfailed. ruff 0.16.2 and mypy 2.3.0 clean.

The following targeted behaviours were mutation-checked: collection traversal and hydration, the batched `agg` branch, recursive child traversal, variadic-tuple shape, `Ellipsis` filtering, abstract sequence and mapping branches at both the converter and the runtime guard, every-member traversal, dict key/value recursion, the forward-reference guard, and `python_to_sql` arity.

That process found six tests that could not fail, each since fixed: an aggregator inert because the batched path unwraps to the model; a `UserDict` holder inert because validation coerces it to `dict`; string keys spelled `"foo"`, which is not valid JSON, so the fallback hid any decoding change; singleton collections that could not show whether traversal passed the first element; a reader comparison sharing mutable data between both readers; and a parallel test that ran serially, since parallelism is disabled at a single row.

## Tracked limitations — not covered here

All pre-existing and requiring source changes:

- [#1917](https://github.com/datachain-ai/datachain/issues/1917) — inferred and name-only UDF outputs skip validation and can vanish from loaded schemas.
- [#1918](https://github.com/datachain-ai/datachain/issues/1918) — `Literal`, `Annotated` and string-enum mapping keys are over-decoded.
- [#1919](https://github.com/datachain-ai/datachain/issues/1919) — `dict` values declared as non-JSON scalars are not coerced on direct or dotted reads (whole-model hydration is correct).
- [#1920](https://github.com/datachain-ai/datachain/issues/1920) — any `Iterable[T]` model field fails to store; `Iterable[File]` setup values additionally get no catalog.
- [#1921](https://github.com/datachain-ai/datachain/issues/1921) — `is_chain_type` accepts `bytes` inside concrete `list`/`dict` trees (element, key or value, including nested), but writing any of them fails.
- [#1923](https://github.com/datachain-ai/datachain/issues/1923) — unparameterized sequence annotations raise from the SQL layer, via `output=list` and via model fields, which bypass `is_chain_type` entirely. Bare `dict` is unaffected.

`test_map_preserves_json_looking_key_for_optional_str_key` pins **current** read-side behaviour for `dict[str | None, int]`. That is the ambiguous domain in [#1914](https://github.com/datachain-ai/datachain/issues/1914); if schema validation later rejects such annotations, this test is expected to change with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
