### PR TITLE
fix(models): rebuild declared key and value types on read

### DIFF
--- a/src/datachain/lib/data_model.py
+++ b/src/datachain/lib/data_model.py
@@ -1,12 +1,26 @@
+import functools
 import hashlib
 import inspect
+import operator
 import types
 import uuid
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import datetime
-from typing import Any, ClassVar, Union, get_args, get_origin
+from enum import Enum
+from typing import (
+    Annotated,
+    Any,
+    ClassVar,
+    Literal,
+    NewType,
+    TypeGuard,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
 
 from pydantic import AliasChoices, BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
@@ -14,6 +28,15 @@ from pydantic.fields import FieldInfo
 from datachain import json
 from datachain.lib.model_store import ModelStore
 from datachain.lib.utils import normalize_col_names, type_to_str
+
+_TYPE_ALIAS_TYPES: tuple[type, ...] = tuple(
+    alias
+    for alias in (
+        getattr(types, "TypeAliasType", None),
+        getattr(__import__("typing"), "TypeAliasType", None),
+    )
+    if isinstance(alias, type)
+)
 
 _skip_optional_promotion: ContextVar[bool] = ContextVar(
     "_skip_optional_promotion", default=False
@@ -188,20 +211,259 @@ def annotation_parts(t: Any) -> tuple[Any, ...]:
     return ()
 
 
+def _is_new_type(t: Any) -> bool:
+    """Whether `t` is an actual `typing.NewType`, not merely shaped like one."""
+    return isinstance(t, NewType)
+
+
+def _is_type_alias(t: Any) -> bool:
+    """Whether `t` is an actual PEP-695 alias, not merely shaped like one.
+
+    Attribute-shaped duck typing would misread a user model that happens to
+    define `__value__`, so the concrete type is what decides.
+    """
+    return bool(_TYPE_ALIAS_TYPES) and isinstance(t, _TYPE_ALIAS_TYPES)
+
+
+def _effective_alias_args(alias: Any, supplied: tuple[Any, ...]) -> "tuple | None":
+    """Arguments for `alias`, filling PEP-696 defaults, or `None` if incomplete."""
+    params = getattr(alias, "__type_params__", ())
+    if len(supplied) > len(params):
+        return None
+    args = list(supplied)
+    for param in params[len(supplied) :]:
+        if not getattr(param, "has_default", lambda: False)():
+            return None
+        args.append(param.__default__)
+    return tuple(args)
+
+
+def _substitute_type_vars(t: Any, mapping: "dict[Any, Any]") -> Any:
+    """Replace type variables in `t` using `mapping`, as far as is reproducible."""
+    if isinstance(t, TypeVar):
+        return mapping.get(t, t)
+    args = get_args(t)
+    if not args:
+        return t
+    new_args = tuple(_substitute_type_vars(a, mapping) for a in args)
+    if new_args == args:
+        return t
+    try:
+        return _rebuild_with_args(t, new_args)
+    except Exception:  # noqa: BLE001 - typing internals vary across versions
+        return t
+
+
+def _rebuild_with_args(t: Any, new_args: tuple[Any, ...]) -> Any:
+    """Rebuild the generic `t` with `new_args` substituted in."""
+    origin = get_origin(t)
+    if origin is Annotated:
+        return Annotated[new_args]
+    if origin in (Union, types.UnionType):
+        # runtime rebuild from a tuple; `X | Y` has no splat form
+        return Union[new_args]  # noqa: UP007
+    if (copy_with := getattr(t, "copy_with", None)) is not None:
+        return copy_with(new_args)
+    # class subscription, not the origin's own __getitem__
+    return origin[new_args]
+
+
+def _resolve_generic_alias(t: Any) -> Any:
+    """Substitute a PEP-695 alias, e.g. `Key[str]` where `type Key[T] = T`.
+
+    Handles the unsubscripted form too when every parameter carries a PEP-696
+    default. Returns `t` unchanged when the parameters cannot be filled in.
+    """
+    alias = get_origin(t) if _is_type_alias(get_origin(t)) else t
+    if not _is_type_alias(alias) or not getattr(alias, "__type_params__", ()):
+        return t
+    args = _effective_alias_args(alias, get_args(t))
+    if args is None:
+        return t
+    return _substitute_type_vars(
+        alias.__value__, dict(zip(alias.__type_params__, args, strict=True))
+    )
+
+
+def alias_cycle_key(t: Any) -> Any:
+    """A stable key identifying an alias application, or `None`.
+
+    Object identity is unusable here: intermediate alias objects are freed and
+    their ids reused, and substitution mints a fresh object every pass, so a
+    finite chain can look cyclic and a genuine cycle can look finite.
+    """
+    origin = get_origin(t)
+    alias = origin if _is_type_alias(origin) else t
+    if not _is_type_alias(alias):
+        return None
+    try:
+        return (alias, get_args(t))
+    except TypeError:
+        return None
+
+
+def unwrap_alias(t: Any) -> Any:
+    """Strip `Annotated`, `NewType` and PEP-695 alias wrappers from `t`.
+
+    Each is transparent for storage: the DB sees whatever the wrapped type
+    produces, so every read-side decision must be made on the inner type.
+
+    Alias parameters are substituted, including PEP-696 defaults, so `Key[str]`
+    behaves as `str`. An alias body is used even when parameters remain free, so
+    `type TupleKey[T] = tuple[T, ...]` keeps its shape. Recursive aliases stop at
+    the repeat rather than spinning.
+    """
+    seen: set[Any] = set()
+    while True:
+        if (cycle_key := alias_cycle_key(t)) is not None:
+            if cycle_key in seen:
+                return t
+            seen.add(cycle_key)
+        if get_origin(t) is Annotated:
+            t = get_args(t)[0]
+        elif _is_new_type(t):
+            t = t.__supertype__
+        elif (resolved := _resolve_generic_alias(t)) is not t:
+            t = resolved
+        elif _is_type_alias(t):
+            t = t.__value__
+        else:
+            return t
+
+
+def literal_members(t: Any) -> tuple[Any, ...]:
+    """Members of a `Literal`, gathered through aliases and unions, `()` if none.
+
+    Members are returned as declared, so an `Enum` member stays a member rather
+    than collapsing to its value.
+    """
+    t = unwrap_alias(t)
+    if get_origin(t) is Literal:
+        return get_args(t)
+    if get_origin(t) in (Union, types.UnionType):
+        return tuple(m for p in annotation_parts(t) for m in literal_members(p))
+    return ()
+
+
+def union_arms(t: Any) -> tuple[Any, ...]:
+    """The arms of a union, normalised, or `(t,)` for a non-union."""
+    t = unwrap_alias(t)
+    if get_origin(t) in (Union, types.UnionType):
+        return tuple(unwrap_alias(p) for p in annotation_parts(t))
+    return (t,)
+
+
+def resolve_literal_member(t: Any, value: Any) -> Any:
+    """The declared `Literal` member equal to `value`, or `None` if there is none.
+
+    Exact type wins over mere equality, in two steps. `Literal[Colour.RED, "red"]`
+    resolves a stored `"red"` to the plain string member rather than the enum,
+    which matches pydantic and makes the answer independent of declaration order.
+    And a *non-Literal* arm whose type matches exactly keeps the value as it is:
+    `True == 1 == 1.0` in Python, so `Literal[1] | bool` must not turn a stored
+    `True` into `1`.
+    """
+    members = literal_members(t)
+    if not members:
+        return None
+    for member in members:
+        if type(member) is type(value) and member == value:
+            return member
+    for arm in union_arms(t):
+        if get_origin(arm) is None and arm is type(value):
+            return None
+    for member in members:
+        # `True == 1` and `1 == 1.0`: never let a bool cross-match a number
+        if isinstance(member, bool) == isinstance(value, bool) and member == value:
+            return member
+    return None
+
+
+def is_enum_annotation(t: Any) -> TypeGuard[type[Enum]]:
+    """Whether `t` is an `Enum` subclass, whose members the DB stores as values."""
+    return inspect.isclass(t) and issubclass(t, Enum)
+
+
+def _enum_values_are_strings(t: Any) -> bool:
+    return is_enum_annotation(t) and all(isinstance(member.value, str) for member in t)
+
+
+def type_var_target(t: Any) -> Any:
+    """The most specific type a type variable can stand for, or `None`.
+
+    A PEP-696 default, a bound, or a constraint set narrows what may have been
+    stored; an unconstrained variable narrows nothing.
+    """
+    if not isinstance(t, TypeVar):
+        return None
+    if getattr(t, "has_default", lambda: False)():
+        return getattr(t, "__default__", None)  # PEP-696, Python 3.13+
+    if t.__bound__ is not None:
+        return t.__bound__
+    if t.__constraints__:
+        return functools.reduce(operator.or_, t.__constraints__)
+    return None
+
+
+def resolve_type_var(t: Any) -> Any:
+    """`t` with a type variable replaced by what it can stand for."""
+    return type_var_target(t) or t if isinstance(t, TypeVar) else t
+
+
 def key_needs_json_decode(t: Any) -> bool:
-    """Whether mapping keys of type `t` are JSON-encoded in the DB.
+    """Whether some key of type `t` may be JSON-encoded in the DB.
 
     Keys are stored as strings, so `dict[int, ...]` reads back as `{"1": ...}`
-    and needs decoding, but a key type that can be a plain string must not --
-    `"foo"` is not valid JSON.
+    and needs decoding. This is the annotation-level question used to decide
+    whether a mapping needs converting at all; whether a *particular* key was
+    stored verbatim is `key_is_stored_verbatim`.
     """
-    if t is str or t is Any:
+    t = unwrap_alias(t)
+    if isinstance(t, TypeVar):
+        target = type_var_target(t)
+        # an unconstrained variable says nothing: do not risk decoding
+        return target is not None and key_needs_json_decode(target)
+    if t is str or t is Any or _is_type_alias(t):
+        # still an alias after unwrapping means a cycle we could not resolve
+        return False
+    if get_origin(t) is Literal:
+        return any(not isinstance(v, str) for v in get_args(t))
+    if _enum_values_are_strings(t) or (inspect.isclass(t) and issubclass(t, str)):
+        # a string-valued enum may be stored verbatim, so a key must be offered
+        # to the converter rather than decoded blind
         return False
     if get_origin(t) in (Union, types.UnionType):
-        # one arm that can be a plain string makes decoding unsafe for all of them
-        return all(key_needs_json_decode(p) for p in annotation_parts(t))
+        # any arm that may be encoded is enough to warrant looking at the key
+        return any(key_needs_json_decode(p) for p in annotation_parts(t))
     # a collection key is never a plain string, whatever its components are
     return True
+
+
+def key_is_stored_verbatim(t: Any, key: str) -> bool:
+    """Whether this exact stored `key` should be taken as a plain string.
+
+    `Literal` needs the key itself to decide: `Literal["a", 1]` stores `"a"`
+    verbatim but JSON-encodes `1`, and the same holds under a union or
+    `Optional` wrapper. A type that admits *any* string -- `str` itself, a `str`
+    subclass, a string-valued enum -- takes every key verbatim.
+    """
+    t = unwrap_alias(t)
+    if isinstance(t, TypeVar) or t is str or t is Any or _is_type_alias(t):
+        # a type variable defers to its target; anything still aliased after
+        # unwrapping is a cycle we could not resolve, and neither may be decoded
+        target = type_var_target(t) if isinstance(t, TypeVar) else None
+        return target is None or key_is_stored_verbatim(target, key)
+    if get_origin(t) is Literal:
+        return any(isinstance(v, str) and v == key for v in get_args(t))
+    if is_enum_annotation(t):
+        # finite, so only an actual member value is stored verbatim; anything
+        # else must stay available for the other union arms to decode
+        return any(member.value == key for member in t)
+    if inspect.isclass(t) and issubclass(t, str):
+        return True
+    if get_origin(t) in (Union, types.UnionType):
+        return any(key_is_stored_verbatim(p, key) for p in annotation_parts(t))
+    return False
 
 
 def unwrap_optional(t: Any) -> tuple[Any, bool]:

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -47,13 +47,21 @@ from datachain.lib.data_model import (
     DataModel,
     DataType,
     DataValue,
+    alias_cycle_key,
     annotation_parts,
     compute_model_fingerprint,
+    is_enum_annotation,
     is_mapping_annotation,
     is_sequence_annotation,
     is_tuple_annotation,
+    key_is_stored_verbatim,
     key_needs_json_decode,
+    literal_members,
+    resolve_literal_member,
+    resolve_type_var,
     skip_optional_promotion,
+    union_arms,
+    unwrap_alias,
     unwrap_optional,
 )
 from datachain.lib.file import File
@@ -689,25 +697,42 @@ class SignalSchema:
         }
 
     @classmethod
-    def _requires_row_conversion(cls, annotation: DataType) -> bool:
+    def _requires_row_conversion(
+        cls, annotation: DataType, _seen: frozenset = frozenset()
+    ) -> bool:
+        key = alias_cycle_key(annotation)
+        annotation = unwrap_alias(annotation)
+        if key is not None:
+            if key in _seen:
+                # `type Tree[T] = list[Tree[T]]` mints a fresh object each pass,
+                # so the repeat has to be recognised structurally, not by id
+                return False
+            _seen = _seen | {key}
+        return cls._conversion_required(annotation, _seen)
+
+    @classmethod
+    def _conversion_required(cls, annotation: DataType, _seen: frozenset) -> bool:
+        annotation = resolve_type_var(annotation)
+
         if ModelStore.is_pydantic(annotation):
             return True
 
         if get_origin(annotation) in (Union, types.UnionType):
             inner, has_none = unwrap_optional(annotation)
-            return has_none and cls._requires_row_conversion(inner)
+            return has_none and cls._requires_row_conversion(inner, _seen)
         parts = annotation_parts(annotation)
         if is_mapping_annotation(annotation):
             return len(parts) == 2 and (
                 key_needs_json_decode(parts[0])
-                or cls._requires_row_conversion(parts[1])
+                or cls._requires_row_conversion(parts[0], _seen)
+                or cls._requires_row_conversion(parts[1], _seen)
             )
         if is_sequence_annotation(annotation):
             # a declared tuple always needs rebuilding: the DB hands back a list
             if is_tuple_annotation(annotation):
                 return bool(parts)
-            return any(cls._requires_row_conversion(part) for part in parts)
-        return False
+            return any(cls._requires_row_conversion(part, _seen) for part in parts)
+        return is_enum_annotation(annotation) or bool(literal_members(annotation))
 
     @staticmethod
     def _annotation_contains_type(annotation: Any, target: type) -> bool:
@@ -907,15 +932,29 @@ class SignalSchema:
             return None
 
         result = value
+        annotation = resolve_type_var(unwrap_alias(annotation))
+
+        if (member := resolve_literal_member(annotation, value)) is not None:
+            # a Literal must yield its declared member, not the stored value
+            return member
+
         origin = get_origin(annotation)
 
         if origin in (Union, types.UnionType):
             inner, has_none = unwrap_optional(annotation)
             # a None-free or multi-arm Union isn't converted to a single type
             if not has_none or get_origin(inner) in (Union, types.UnionType):
-                return result
-            annotation = inner
+                # the union as a whole stays as stored, but a value that is an
+                # actual member of one arm is rebuilt as that member
+                return self._enum_member_in_union(annotation, value, result)
+            # the arm may itself be wrapped, so normalise again
+            annotation = unwrap_alias(inner)
             origin = get_origin(annotation)
+
+        if is_enum_annotation(annotation):
+            # strict, like pydantic: an unknown value is an error, not a silent
+            # pass-through. Mapping keys catch this and keep the raw key.
+            return annotation(value)
 
         if ModelStore.is_pydantic(annotation):
             if isinstance(value, annotation):
@@ -952,27 +991,58 @@ class SignalSchema:
             parts = annotation_parts(annotation)
             if len(parts) == 2 and isinstance(value, Mapping):
                 key_type, val_type = parts
-                decode_keys = key_needs_json_decode(key_type)
-                result = {}
-                for key, val in value.items():
-                    converted_key = key
-                    if decode_keys:
-                        try:
-                            converted_key = self._convert_feature_value(
-                                key_type, json.loads(key), catalog, cache
-                            )
-                        except ValueError:
-                            # Declared type and stored key disagree; keep the raw key
-                            # rather than failing the whole row.
-                            converted_key = key
-                    converted_val = (
+                result = {
+                    self._convert_mapping_key(key_type, key, catalog, cache): (
                         self._convert_feature_value(val_type, val, catalog, cache)
                         if val_type is not Any
                         else val
                     )
-                    result[converted_key] = converted_val
+                    for key, val in value.items()
+                }
 
         return result
+
+    @staticmethod
+    def _enum_member_in_union(annotation: Any, value: Any, default: Any) -> Any:
+        """Rebuild `value` as an enum member of one of `annotation`'s arms."""
+        for arm in union_arms(annotation):
+            if is_enum_annotation(arm):
+                try:
+                    return arm(value)
+                except ValueError:
+                    continue
+        return default
+
+    def _convert_mapping_key(
+        self,
+        key_type: DataType,
+        raw_key: Any,
+        catalog: "Catalog | None",
+        cache: bool,
+    ) -> Any:
+        """Restore one stored mapping key to its declared type.
+
+        Keys are stored as strings. Types that cannot hold a plain string are
+        JSON-encoded and decoded back here; the rest are stored verbatim. Either
+        way the result still goes through the converter, so a declared enum
+        arrives as its member rather than the raw value.
+        """
+        decoded = raw_key
+        if not key_is_stored_verbatim(key_type, raw_key):
+            try:
+                decoded = json.loads(raw_key)
+            except ValueError:
+                # Declared type and stored key disagree; keep the stored key
+                # rather than failing the whole row.
+                return raw_key
+        try:
+            return self._convert_feature_value(key_type, decoded, catalog, cache)
+        except ValueError:
+            # e.g. a value outside the declared enum, or a model the stored key
+            # cannot build. Every fallback yields the *stored* key, since the
+            # decoded object may not even be hashable. Leniency is deliberate
+            # for keys only; ordinary values raise, as pydantic would.
+            return raw_key
 
     @staticmethod
     def _set_file_stream(

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -7,6 +7,8 @@ import re
 import uuid
 from collections import Counter
 from collections.abc import Generator, Iterator
+from enum import Enum, IntEnum
+from typing import Annotated, Literal
 from unittest.mock import ANY, patch
 
 import numpy as np
@@ -14,7 +16,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 import datachain as dc
 import datachain.query.dataset as query_dataset
@@ -5653,3 +5655,115 @@ def test_count_after_limit_then_distinct(test_session, boundary_counter):
 
     assert chain.limit(4).distinct("session_id", "position").count() == 2
     boundary_counter.assert_count(1)
+
+
+class SessionKey(str, Enum):
+    NULL = "null"
+
+
+class SessionCode(IntEnum):
+    ONE = 1
+
+
+@pytest.mark.parametrize(
+    "annotation,value,pick",
+    [
+        (dict[SessionKey, int], {SessionKey.NULL: 1}, lambda m: next(iter(m))),
+        (dict[Literal["null"], int], {"null": 1}, lambda m: next(iter(m))),
+        (
+            dict[Annotated[SessionKey, "meta"], int],
+            {SessionKey.NULL: 1},
+            lambda m: next(iter(m)),
+        ),
+        (dict[str, SessionKey], {"k": SessionKey.NULL}, lambda m: m["k"]),
+        (dict[str, SessionCode], {"k": SessionCode.ONE}, lambda m: m["k"]),
+    ],
+    ids=[
+        "str-enum-key",
+        "literal-key",
+        "annotated-enum-key",
+        "str-enum-value",
+        "int-enum-value",
+    ],
+)
+def test_dotted_param_and_whole_model_agree_on_mapping(
+    test_session, annotation, value, pick
+):
+    holder = type("Holder", (DataModel,), {"__annotations__": {"m": annotation}})
+
+    def describe(obj):
+        return f"{obj!r} ({type(obj).__name__})"
+
+    saved = dc.read_values(x=[holder(m=value)], session=test_session).save("agree")
+
+    (dotted,) = saved.map(
+        k=lambda m: describe(pick(m)), params=["x.m"], output=str
+    ).to_values("k")
+    (whole,) = saved.map(k=lambda x: describe(pick(x.m)), output=str).to_values("k")
+    (direct,) = saved.to_values("x.m")
+
+    assert dotted == whole
+    assert describe(pick(direct)) == whole
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#1942: pydantic rejects the stored key for a non-string Literal member",
+)
+def test_literal_int_key_agrees_across_routes(test_session):
+    class Holder(DataModel):
+        m: dict[Literal["a", 1], int]
+
+    saved = dc.read_values(x=[Holder(m={1: 5})], session=test_session).save("mixed")
+
+    (dotted,) = saved.to_values("x.m")
+    (whole,) = saved.to_values("x")
+
+    assert next(iter(dotted)) == next(iter(whole.m))
+
+
+@pytest.mark.parametrize(
+    "annotation,value,pick",
+    [
+        (dict[SessionKey, int], {SessionKey.NULL: 1}, lambda m: next(iter(m))),
+        (dict[str, SessionKey], {"k": SessionKey.NULL}, lambda m: m["k"]),
+    ],
+    ids=["key", "value"],
+)
+def test_use_enum_values_reads_the_declared_annotation_on_the_dotted_route(
+    test_session, annotation, value, pick
+):
+    class Loose(DataModel):
+        model_config = ConfigDict(use_enum_values=True)
+        m: annotation  # type: ignore[valid-type]
+
+    saved = dc.read_values(x=[Loose(m=value)], session=test_session).save("loose")
+
+    dotted = pick(saved.to_values("x.m")[0])
+    whole = pick(saved.to_values("x")[0].m)
+
+    # an accepted breaking change: the declared annotation decides what a read
+    # produces, so the dotted route yields the member. `use_enum_values` shapes
+    # model construction, which only the whole-model route goes through. The
+    # type assertions matter: SessionKey.NULL == "null" is true. See #1932.
+    assert dotted is SessionKey.NULL
+    assert type(whole) is str
+    assert whole == SessionKey.NULL.value
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#1932: a dotted selection does not carry model config"
+)
+def test_use_enum_values_agrees_across_routes(test_session):
+    class Loose(DataModel):
+        model_config = ConfigDict(use_enum_values=True)
+        m: dict[SessionKey, int]
+
+    saved = dc.read_values(
+        x=[Loose(m={SessionKey.NULL: 1})], session=test_session
+    ).save("loose_agree")
+
+    dotted = next(iter(saved.to_values("x.m")[0]))
+    whole = next(iter(saved.to_values("x")[0].m))
+
+    assert type(dotted) is type(whole)

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1,13 +1,20 @@
 import json
 import pickle
+import subprocess
+import sys
 from collections import UserDict, UserList
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import datetime
+from enum import Enum, IntEnum
 from typing import (
+    Annotated,
     Any,
+    ClassVar,
     Final,
     ForwardRef,
     Generic,
+    Literal,
+    NewType,
     Optional,
     TypeVar,
     Union,
@@ -1060,6 +1067,302 @@ def test_row_to_objs_dict_key_decoding_policy(key_type, raw, expected):
     (converted,) = SignalSchema({"m": dict[key_type, int]}).row_to_objs((raw,))
 
     assert converted == expected
+
+
+class KeyEnum(str, Enum):
+    NULL = "null"
+
+
+class KeyIntEnum(IntEnum):
+    ONE = 1
+
+
+class PlainKeyEnum(Enum):
+    A = "a"
+
+
+class KeyEnum2(str, Enum):
+    A = "a"
+
+
+class MixedKeyEnum(Enum):
+    NULL = "null"
+    ONE = 1
+
+
+class AliasLookalike(DataModel):
+    __value__: ClassVar[type] = int
+    x: int
+
+
+class UnbuildableKey(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    a: int
+
+
+@pytest.mark.parametrize(
+    "key_type,raw,expected",
+    [
+        (Literal["null", "ok"], "null", "null"),
+        (Literal["a", 1], "a", "a"),
+        (Literal["a", 1], "1", 1),
+        (Literal["1", 1], "1", "1"),
+        (Literal["[]"], "[]", "[]"),
+        (Annotated[str, "meta"], "null", "null"),
+        (KeyEnum, "null", KeyEnum.NULL),
+        (Literal[1, 2], "1", 1),
+        (Annotated[int, "meta"], "1", 1),
+        (KeyIntEnum, "1", KeyIntEnum.ONE),
+    ],
+    ids=[
+        "literal-str",
+        "literal-mixed-string-arm",
+        "literal-mixed-int-arm",
+        "literal-ambiguous",
+        "literal-bracket",
+        "annotated-str",
+        "str-enum",
+        "literal-int",
+        "annotated-int",
+        "int-enum",
+    ],
+)
+def test_row_to_objs_restores_declared_dict_key_type(key_type, raw, expected):
+    (converted,) = SignalSchema({"m": dict[key_type, int]}).row_to_objs(({raw: 1},))
+
+    (key,) = converted
+    assert key == expected
+    assert type(key) is type(expected)
+
+
+@pytest.mark.parametrize(
+    "key_type,raw,expected",
+    [
+        (Optional[Literal["null", 1]], "null", "null"),
+        (Optional[Literal["null", 1]], "1", 1),
+        (Optional[Literal["[]", 1]], "[]", "[]"),
+        (Union[Literal["a"], int], "1", 1),
+        (Annotated[Optional[KeyEnum], "meta"], "null", KeyEnum.NULL),
+        (Optional[Annotated[KeyEnum, "meta"]], "null", KeyEnum.NULL),
+        (PlainKeyEnum, "a", PlainKeyEnum.A),
+    ],
+    ids=[
+        "optional-literal-string-arm",
+        "optional-literal-int-arm",
+        "optional-literal-bracket",
+        "union-literal-int-arm",
+        "alias-outside-optional",
+        "alias-inside-optional",
+        "enum-without-str-mixin",
+    ],
+)
+def test_row_to_objs_resolves_wrapped_dict_key(key_type, raw, expected):
+    (converted,) = SignalSchema({"m": dict[key_type, int]}).row_to_objs(({raw: 1},))
+
+    (key,) = converted
+    assert key == expected
+    assert type(key) is type(expected)
+
+
+@pytest.mark.parametrize(
+    "key_type,raw",
+    [
+        (KeyEnum, "nope"),
+        (KeyIntEnum, "2"),
+        (UnbuildableKey, "{}"),
+        (UnbuildableKey, "x"),
+    ],
+    ids=["unknown-str-enum", "unknown-int-enum", "unhashable-decode", "undecodable"],
+)
+def test_row_to_objs_keeps_the_stored_key_when_conversion_fails(key_type, raw):
+    (converted,) = SignalSchema({"m": dict[key_type, int]}).row_to_objs(({raw: 1},))
+
+    assert converted == {raw: 1}
+    (key,) = converted
+    assert type(key) is str
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="PEP 695 type aliases need Python 3.12"
+)
+def test_recursive_alias_does_not_stall_the_conversion_gate():
+    namespace: dict = dict(globals())
+    exec("type Recursive = list[Recursive]", namespace)  # noqa: S102
+
+    assert SignalSchema._requires_row_conversion(namespace["Recursive"]) is False
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="PEP 695 type aliases need Python 3.12"
+)
+@pytest.mark.xfail(strict=True, reason="#1942: alias specialisations are not stored")
+def test_generic_alias_specialisation_survives_a_reload():
+    namespace: dict = dict(globals())
+    exec("type Key[T] = T", namespace)  # noqa: S102
+
+    specialised = namespace["Key"][str]
+    holder = type(
+        "Holder", (DataModel,), {"__annotations__": {"m": dict[specialised, int]}}
+    )
+
+    reloaded = SignalSchema.deserialize(SignalSchema({"Holder": holder}).serialize())
+
+    # what matters is the behaviour a reload produces, not the exact spelling
+    # `type_to_str` chose; expanding to `str` would be an equally valid fix
+    (converted,) = reloaded.row_to_objs(({"null": 1},))
+    assert next(iter(converted)) == "null"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("1", 1), ("a", KeyEnum2.A)],
+    ids=["non-member-decodes", "member-rebuilds"],
+)
+def test_row_to_objs_lets_union_arms_past_a_finite_enum(raw, expected):
+    schema = SignalSchema({"m": dict[KeyEnum2 | int, int]})
+
+    (converted,) = schema.row_to_objs(({raw: 1},))
+
+    (key,) = converted
+    assert key == expected
+    assert type(key) is type(expected)
+
+
+def test_row_to_objs_rebuilds_a_mixed_value_enum_key():
+    (converted,) = SignalSchema({"m": dict[MixedKeyEnum, int]}).row_to_objs(
+        ({"null": 1},)
+    )
+
+    assert next(iter(converted)) is MixedKeyEnum.NULL
+
+
+@pytest.mark.parametrize(
+    "bound,raw,expected",
+    [(KeyIntEnum, "1", KeyIntEnum.ONE), (KeyEnum2, "a", KeyEnum2.A)],
+    ids=["int-enum-bound", "str-enum-bound"],
+)
+def test_row_to_objs_rebuilds_through_a_bounded_type_var(bound, raw, expected):
+    Bounded = TypeVar("Bounded", bound=bound)
+
+    (converted,) = SignalSchema({"m": dict[Bounded, int]}).row_to_objs(({raw: 1},))
+
+    (key,) = converted
+    assert key is expected
+
+
+def test_row_to_objs_keeps_a_model_that_merely_looks_like_an_alias():
+    (converted,) = SignalSchema({"m": dict[str, AliasLookalike]}).row_to_objs(
+        ({"a": {"x": 1}},)
+    )
+
+    assert converted["a"] == AliasLookalike(x=1)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="PEP 695 type aliases need Python 3.12"
+)
+def test_recursive_generic_alias_does_not_stall_the_conversion_gate():
+    namespace: dict = dict(globals())
+    exec("type Tree[T] = list[Tree[T]]", namespace)  # noqa: S102
+
+    # substitution mints a fresh object each pass, so an identity guard never
+    # recognises the repeat
+    assert SignalSchema._requires_row_conversion(namespace["Tree"][int]) is False
+
+
+def test_row_to_objs_rebuilds_enum_dict_value():
+    (converted,) = SignalSchema({"m": dict[str, KeyEnum]}).row_to_objs(({"k": "null"},))
+
+    assert converted["k"] is KeyEnum.NULL
+
+
+def test_row_to_objs_rebuilds_int_enum_literal_value():
+    schema = SignalSchema({"m": dict[str, Literal[KeyIntEnum.ONE]]})
+
+    (converted,) = schema.row_to_objs(({"k": 1},))
+
+    assert converted["k"] is KeyIntEnum.ONE
+
+
+def test_row_to_objs_keeps_key_outside_the_declared_enum():
+    (converted,) = SignalSchema({"m": dict[KeyEnum, int]}).row_to_objs(({"nope": 1},))
+
+    assert converted == {"nope": 1}
+
+
+@pytest.mark.parametrize(
+    "annotation,raw",
+    [
+        (dict[str, KeyEnum], {"k": "nope"}),
+        (list[KeyEnum], ["nope"]),
+    ],
+    ids=["value", "item"],
+)
+def test_row_to_objs_rejects_value_outside_the_declared_enum(annotation, raw):
+    with pytest.raises(ValueError, match="not a valid KeyEnum"):
+        SignalSchema({"m": annotation}).row_to_objs((raw,))
+
+
+@pytest.mark.parametrize(
+    "key_type,raw,expected",
+    [
+        (Annotated[KeyEnum, "meta"], "null", KeyEnum.NULL),
+        (Literal[KeyEnum.NULL], "null", KeyEnum.NULL),
+        (NewType("StrKeyAlias", str), "null", "null"),
+        (NewType("IntKeyAlias", int), "1", 1),
+    ],
+    ids=["annotated-enum", "literal-enum", "newtype-str", "newtype-int"],
+)
+def test_row_to_objs_sees_through_key_wrappers(key_type, raw, expected):
+    (converted,) = SignalSchema({"m": dict[key_type, int]}).row_to_objs(({raw: 1},))
+
+    (key,) = converted
+    assert key == expected
+    assert type(key) is type(expected)
+
+
+RELOAD_IN_CLEAN_PROCESS = """
+import json, sys
+from datachain.lib.signal_schema import SignalSchema
+fields = SignalSchema.deserialize(json.loads(sys.argv[1])).values["Holder"].model_fields
+print(fields["lit"].annotation, "|", fields["enm"].annotation)
+"""
+
+
+@pytest.mark.xfail(strict=True, reason="#1942: type_to_str drops Literal arguments")
+def test_literal_arguments_survive_serialization():
+    class Holder(DataModel):
+        lit: dict[Literal["a"], int]
+
+    payload = SignalSchema({"Holder": Holder}).serialize()
+
+    assert payload["_custom_types"]["Holder@v1"]["fields"]["lit"] == (
+        "dict[Literal['a'], int]"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#1942: Literal and enum key types do not survive a reload"
+)
+def test_literal_and_enum_keys_survive_a_clean_process_reload():
+    class Shade(str, Enum):
+        A = "a"
+
+    class Holder(DataModel):
+        lit: dict[Literal["a"], int]
+        enm: dict[Shade, int]
+
+    payload = json.dumps(SignalSchema({"Holder": Holder}).serialize())
+
+    # must fork: in-process ModelStore returns the original class and hides this
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", RELOAD_IN_CLEAN_PROCESS, payload],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() != "dict[typing.Any, int] | dict[typing.Any, int]"
 
 
 def test_row_to_features_does_not_decode_string_keys(test_session):

--- a/tests/unit/test_data_model.py
+++ b/tests/unit/test_data_model.py
@@ -1,6 +1,20 @@
 import copy
+import gc
+import sys
 from collections.abc import Collection, Iterable, Mapping, Sequence
-from typing import Dict, Generic, List, TypeVar  # noqa: UP035
+from enum import Enum, IntEnum
+from typing import (  # noqa: UP035
+    Annotated,
+    Any,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    NewType,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 import pytest
 
@@ -11,6 +25,10 @@ from datachain.lib.data_model import (
     DataModel,
     compute_model_fingerprint,
     is_chain_type,
+    key_is_stored_verbatim,
+    key_needs_json_decode,
+    resolve_literal_member,
+    unwrap_alias,
 )
 from datachain.lib.model_store import ModelStore
 
@@ -185,3 +203,308 @@ def test_is_chain_type_accepts_bare_dict():
 )
 def test_is_chain_type_rejects_unsupported_bare_collection_roots(annotation):
     assert is_chain_type(annotation) is False
+
+
+class StringKey(str, Enum):
+    NULL = "null"
+    OK = "ok"
+
+
+class NumberKey(IntEnum):
+    ONE = 1
+
+
+class PlainValueKey(Enum):
+    A = "a"
+
+
+class StringKey2(str, Enum):
+    A = "a"
+
+
+StringAlias = NewType("StringAlias", str)
+NumberAlias = NewType("NumberAlias", int)
+
+
+@pytest.mark.parametrize(
+    "annotation,needs_decode",
+    [
+        (str, False),
+        (Any, False),
+        (str | None, False),
+        (Literal["null", "ok"], False),
+        (Literal["a", 1], True),
+        (Annotated[str, "meta"], False),
+        (StringKey, False),
+        (int, True),
+        (Literal[1, 2], True),
+        (Annotated[int, "meta"], True),
+        (NumberKey, True),
+        (tuple[int, int], True),
+        (StringAlias, False),
+        (NumberAlias, True),
+    ],
+    ids=[
+        "str",
+        "any",
+        "optional-str",
+        "literal-str",
+        "literal-mixed",
+        "annotated-str",
+        "str-enum",
+        "int",
+        "literal-int",
+        "annotated-int",
+        "int-enum",
+        "tuple",
+        "newtype-str",
+        "newtype-int",
+    ],
+)
+def test_key_needs_json_decode(annotation, needs_decode):
+    assert key_needs_json_decode(annotation) is needs_decode
+
+
+@pytest.mark.parametrize(
+    "annotation,key,verbatim",
+    [
+        (Literal["a", 1], "a", True),
+        (Literal["a", 1], "1", False),
+        (Literal["1", 1], "1", True),
+        (Literal[1, 2], "1", False),
+        (str, "1", True),
+        (int, "1", False),
+        (StringKey, "null", True),
+        # wrappers and unions must not hide the string members
+        (Optional[Literal["null", 1]], "null", True),  # noqa: UP045
+        (Literal["null", 1] | None, "1", False),
+        (Literal["[]", 1] | None, "[]", True),
+        (Union[Literal["a"], int], "a", True),  # noqa: UP007
+        (Literal["a"] | int, "1", False),
+        (Annotated[Literal["a", 1], "meta"], "a", True),
+        (PlainValueKey, "a", True),
+    ],
+    ids=[
+        "mixed-string-arm",
+        "mixed-int-arm",
+        "ambiguous-prefers-string",
+        "all-int",
+        "str",
+        "int",
+        "str-enum",
+        "optional-literal-string-arm",
+        "optional-literal-int-arm",
+        "optional-literal-bracket",
+        "union-literal-string-arm",
+        "union-literal-int-arm",
+        "annotated-literal",
+        "plain-enum-with-string-values",
+    ],
+)
+def test_key_is_stored_verbatim(annotation, key, verbatim):
+    assert key_is_stored_verbatim(annotation, key) is verbatim
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="PEP 695 type aliases need Python 3.12"
+)
+@pytest.mark.parametrize(
+    "alias_source,needs_decode",
+    [("type Alias = str", False), ("type Alias = int", True)],
+    ids=["str", "int"],
+)
+def test_key_needs_json_decode_pep695_alias(alias_source, needs_decode):
+    namespace: dict = {}
+    exec(alias_source, namespace)  # noqa: S102
+
+    assert key_needs_json_decode(namespace["Alias"]) is needs_decode
+
+
+@pytest.mark.parametrize(
+    "annotation,value,expected",
+    [
+        (Literal[StringKey.NULL, "null"], "null", "null"),
+        (Literal["null", StringKey.NULL], "null", "null"),
+        (Literal[StringKey.NULL], "null", StringKey.NULL),
+        (Literal[NumberKey.ONE], 1, NumberKey.ONE),
+        (Literal["a", 1], 1, 1),
+        (Literal["a"] | None, "a", "a"),
+        (int, "1", None),
+        # True == 1 == 1.0 in Python, so an exact-type arm must win
+        (Literal[1] | bool, True, None),
+        (Literal[True] | int, 1, None),
+        (Literal[1] | float, 1.0, None),
+        (Literal[NumberKey.ONE] | int, 1, None),
+        (Literal[1], True, None),  # a bool must not match an int member
+    ],
+    ids=[
+        "enum-then-string",
+        "string-then-enum",
+        "enum-only",
+        "int-enum-only",
+        "mixed-int",
+        "through-optional",
+        "not-a-literal",
+        "int-literal-with-bool-arm",
+        "bool-literal-with-int-arm",
+        "int-literal-with-float-arm",
+        "int-enum-literal-with-int-arm",
+        "bool-value-against-int-literal",
+    ],
+)
+def test_resolve_literal_member(annotation, value, expected):
+    resolved = resolve_literal_member(annotation, value)
+
+    assert resolved == expected
+    if expected is not None:
+        assert type(resolved) is type(expected)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="PEP 695 type aliases need Python 3.12"
+)
+@pytest.mark.parametrize(
+    "source,expression,expected",
+    [
+        ("type Key[T] = T", "Key[str]", str),
+        ("type Key[T] = T", "Key[int]", int),
+        ("type Pair[T] = dict[str, T]", "Pair[int]", dict[str, int]),
+        ("type Plain = str", "Plain", str),
+        ("type Wrapped[T] = Annotated[T, 'meta']", "Wrapped[int]", int),
+        ("type MaybeItems[T] = list[T] | None", "MaybeItems[int]", list[int] | None),
+        ("type Fixed[T] = int", "Fixed", int),
+    ],
+    ids=[
+        "param-str",
+        "param-int",
+        "param-nested",
+        "unparameterised",
+        "through-annotated",
+        "through-union",
+        "body-without-the-parameter",
+    ],
+)
+def test_unwrap_alias_substitutes_parameters(source, expression, expected):
+    namespace: dict = dict(globals())
+    exec(source, namespace)  # noqa: S102
+
+    assert unwrap_alias(eval(expression, namespace)) == expected  # noqa: S307
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="PEP 695 type aliases need Python 3.12"
+)
+@pytest.mark.parametrize(
+    "source,name,needs_decode",
+    [
+        ("type Fixed[T] = int", "Fixed", True),
+        ("type TupleKey[T] = tuple[T, ...]", "TupleKey", True),
+        ("type Key[T] = T", "Key", False),
+    ],
+    ids=["body-ignores-the-parameter", "structure-known", "body-is-the-parameter"],
+)
+def test_unsubscripted_alias_is_judged_on_its_body(source, name, needs_decode):
+    namespace: dict = dict(globals())
+    exec(source, namespace)  # noqa: S102
+
+    assert key_needs_json_decode(namespace[name]) is needs_decode
+
+
+@pytest.mark.parametrize(
+    "type_var,needs_decode",
+    [
+        (TypeVar("Bound", bound=int), True),
+        (TypeVar("Constrained", int, float), True),
+        (TypeVar("Free"), False),
+    ],
+    ids=["bound", "constrained", "unconstrained"],
+)
+def test_type_var_is_judged_on_its_bound(type_var, needs_decode):
+    assert key_needs_json_decode(type_var) is needs_decode
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="PEP 695 type aliases need Python 3.12"
+)
+@pytest.mark.parametrize(
+    "source,name",
+    [("type Key[T] = T", "Key"), ("type Loop = Loop", "Loop")],
+    ids=["unsubscripted-parameterised", "self-referential"],
+)
+def test_unresolvable_aliases_are_left_verbatim(source, name):
+    namespace: dict = dict(globals())
+    exec(source, namespace)  # noqa: S102
+    alias = namespace[name]
+
+    # guessing wrong here corrupts data: decoding would turn "null" into None
+    assert key_is_stored_verbatim(alias, "null") is True
+    assert key_needs_json_decode(alias) is False
+
+
+def test_unresolved_type_var_is_left_verbatim():
+    Unknown = TypeVar("Unknown")
+
+    assert key_is_stored_verbatim(Unknown, "null") is True
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="PEP 695 type aliases need Python 3.12"
+)
+def test_alias_chain_resolves_the_same_way_every_time():
+    namespace: dict = dict(globals())
+    exec(  # noqa: S102
+        "type A0[T] = A1[T]\ntype A1[T] = A2[T]\ntype A2[T] = A3[T]\ntype A3[T] = T",
+        namespace,
+    )
+
+    # intermediate aliases are freed between calls; an identity-based cycle
+    # guard would reuse their ids and stop early on later passes
+    results = []
+    for _ in range(5):
+        gc.collect()
+        results.append(unwrap_alias(namespace["A0"][int]))
+
+    assert results == [int] * 5
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 13), reason="PEP 696 defaults need Python 3.13"
+)
+@pytest.mark.parametrize(
+    "source,expression,expected",
+    [
+        ("type Key[T = int] = T", "Key", int),
+        ("type Key[T = int] = T", "Key[str]", str),
+        ("type Pair[A, B = int] = dict[A, B]", "Pair[str]", dict[str, int]),
+    ],
+    ids=["default-only", "default-overridden", "partial-specialisation"],
+)
+def test_unwrap_alias_fills_pep696_defaults(source, expression, expected):
+    namespace: dict = dict(globals())
+    exec(source, namespace)  # noqa: S102
+
+    assert unwrap_alias(eval(expression, namespace)) == expected  # noqa: S307
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 13), reason="PEP 696 defaults need Python 3.13"
+)
+def test_type_var_default_narrows_the_decode_decision():
+    assert key_needs_json_decode(TypeVar("T", default=int)) is True
+
+
+def test_alias_detection_ignores_lookalike_classes():
+    class Lookalike:
+        __value__ = int
+        __supertype__ = int
+
+    assert unwrap_alias(Lookalike) is Lookalike
+
+
+@pytest.mark.parametrize(
+    "key,verbatim",
+    [("a", True), ("1", False), ("zz", False)],
+    ids=["member-value", "non-member", "unknown"],
+)
+def test_enum_key_is_verbatim_only_for_an_actual_member(key, verbatim):
+    assert key_is_stored_verbatim(StringKey2, key) is verbatim


### PR DESCRIPTION
Closes #1918. Rebased onto `main` including #1930.

## What this does

Mapping keys are stored as strings and JSON-decoded on read when the declared type cannot itself be a string. That test recognised only `str`, `Any` and unions, so every other spelling of a string-valued key was decoded anyway:

| declared key type | stored | read back |
|---|---|---|
| `Literal["null", "ok"]` | `"null"` | `None` |
| `Literal["[]"]` | `"[]"` | `TypeError: unhashable type: 'list'` |
| `Annotated[str, ...]` | `"null"` | `None` |
| `class Key(str, Enum)` | `"null"` | `None` |

These annotations are rejected by `is_chain_type` but work as **model fields**, which bypass that check, so the data stores fine and only the read is wrong.

The fix is larger than "stop decoding", which is why the title changed. It has four parts:

1. **Verbatim-or-decode is decided per key.** A `Literal` matches its string members; an enum is finite, so only an actual member value counts and anything else stays available for other union arms to decode. Members are gathered through unions and `Optional`.
2. **Aliases are normalised before every decision**, at the entry of both the conversion gate and the converter, and again after an `Optional` arm is unwrapped. `Annotated`, `NewType` and PEP-695 aliases are detected **by type, not attribute shape**. Parameters are substituted, including PEP-696 defaults and partial specialisations. Cycles use a structural key.
3. **Declared types are rebuilt**: the enum, the `Literal` member, and a type variable's default/bound/constraints. The gate recognises the same shapes so keys, values and sequence items all reach the converter. Unknown enum values raise like pydantic; only mapping keys keep the stored value.
4. **`_convert_mapping_key` never loses the stored key**, so a malformed key cannot leak a decoded, possibly unhashable object.

## Review rounds

Four rounds. Each found defects the previous round's fix introduced; all are reproduced before fixing and covered by tests.

| finding | outcome |
|---|---|
| Alias cycle detection was id-based | `unwrap_alias(A0[int])` returned `int` once then `A2[int]` forever after, in one process. Structural key now; `type Tree[T] = list[Tree[T]]` no longer raises `RecursionError` in the gate. |
| PEP-696 defaults ignored | `type Key[T = int] = T` left `"1"` a string; `Pair[str]` lost both the argument and the default. |
| Finite string-enum unions | `dict[Status \| int, int]` left `"1"` a string and `"a"` a plain `str`. Enums are now matched per key, and a union rebuilds an exact member. |
| Duck-typed alias detection | A model defining `__value__` was reinterpreted, returning `{"x": 1}` instead of `Weird(x=1)`. |
| `Literal` in a union | `True == 1 == 1.0`, so `Literal[1] \| bool` turned `true` into `1`. Exact type now wins across the union. |
| Type-var reconstruction | `TypeVar(bound=IntEnum)` gave plain `int`; the gate now resolves the variable too. |

## Limitations, pinned by strict xfail

- **#1942** — annotations that validation accepts but the storage layer cannot honour. This consolidates the former #1921, #1923, #1927, #1933, #1934 and #1935, and states plainly that the known list is probably incomplete: every instance was found by someone naming a specific spelling, never by a systematic sweep. Four strict xfails here reference it — the non-string `Literal` key, and three reload cases. The reload test asserts *reloaded behaviour*, not a particular `type_to_str` spelling, since expanding the alias would be an equally valid fix; it forks.
- **#1932** — a `use_enum_values` model disagrees between routes. Separate and deliberate: a **breaking change** [recorded on the issue](https://github.com/datachain-ai/datachain/issues/1932#issuecomment-5335904458), where the declared annotation decides what a read produces.

## Explicitly out of scope

- **#1914** — mixed `str`/non-`str` key types lose data at *write* time; unrecoverable on read.
- **Enum writes**, which are #1929's half. This PR is read-side only, and on its own an enum signal cannot be stored at all, so none of its enum work is reachable. Merged with #1929 the pair works end to end — whole-model reads, dotted leaf reads and `list[Enum]` all return members ([measured](https://github.com/datachain-ai/datachain/pull/1929#issuecomment-5337093940)). The two merge cleanly. #1929's own review asks for exactly the read-side reconstruction this PR adds.
- **Enums as declared outputs.** `is_chain_type` rejects an enum at the root even with both PRs, so `output={"k": Species}` and a top-level `dict[Species, int]` raise `UdfSignatureError`. Enums work as model fields, which bypass that check.

## Validation

`tests/unit`: 3188 passed, 37 skipped, 19 xfailed on 3.11. Touched files also clean on **3.10** (621 passed), **3.12**, and **3.13** (642 passed), which is where the PEP-695 and PEP-696 paths execute. ruff 0.16.3 and mypy 2.3.0 clean; `git diff --check` clean.

Mutation testing here is **author-run, not a CI artifact**: I applied targeted mutations by hand and recorded which tests failed. Across the rounds 15 mutations were applied and 14 killed. The survivor is equivalent rather than uncovered — on a `json.loads` failure the decoded variable still holds the stored key, so returning either is indistinguishable. Two earlier survivors were genuine gaps and were closed.

## For the reviewer of #1926

That PR will need a deliberate rebase. This branch splits the key fallback into **two** exits — a JSON-parse failure and a declared-type conversion failure. #1926's warning currently covers only the first, so unknown enum keys would stay silent unless it also reports from the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
