### PR TITLE
Map enum signals by member value type instead of builtin str

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -7,6 +7,7 @@ import string
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Union, cast
 from urllib.parse import urlparse
 
@@ -140,6 +141,8 @@ class AbstractWarehouse(ABC, Serializable):
 
         if isinstance(val, (np.ndarray, np.generic)):
             val = val.tolist()
+        if isinstance(val, Enum):
+            val = val.value
 
         # Optimization: Precompute all the column type variables.
         value_type = type(val)
@@ -150,14 +153,6 @@ class AbstractWarehouse(ABC, Serializable):
 
             item_python_type = self.python_type(col_type.item_type)
 
-            if item_python_type is not list:
-                if isinstance(val[0], item_python_type):
-                    # SQLite ARRAY storage expects a list; tuples/sets must be
-                    # converted to lists even when element types already match.
-                    return list(val)
-                if item_python_type is float and isinstance(val[0], int):
-                    return [float(i) for i in val]
-
             # Optimization: Reuse these values for each function call within the
             # list comprehension.
             item_type_info = (
@@ -166,6 +161,26 @@ class AbstractWarehouse(ABC, Serializable):
                 type(col_type.item_type).__name__,
                 col_name,
             )
+
+            if item_python_type is not list:
+                if isinstance(val[0], item_python_type):
+                    # SQLite ARRAY storage expects a list; tuples/sets must be
+                    # converted to lists even when element types already match.
+                    # Enum elements go through full conversion for validation.
+                    return [
+                        self.convert_type(i, *item_type_info)
+                        if isinstance(i, Enum)
+                        else i
+                        for i in val
+                    ]
+                if item_python_type is float and isinstance(val[0], int):
+                    return [
+                        self.convert_type(i, *item_type_info)
+                        if isinstance(i, Enum)
+                        else float(i)
+                        for i in val
+                    ]
+
             return [self.convert_type(i, *item_type_info) for i in val]
 
         # Special use case with JSON type as we save it as string

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -45,7 +45,10 @@ def python_to_sql(typ):  # noqa: PLR0911
         if issubclass(typ, SQLType):
             return typ
         if issubclass(typ, Enum):
-            value_types = {type(m.value) for m in typ}
+            # __members__, not iteration: EnumMeta.__iter__ skips zero-valued
+            # and composite flag members on 3.11+, which would make the column
+            # type depend on the Python version
+            value_types = {type(m.value) for m in typ.__members__.values()}
             if not value_types:
                 return String
 

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -31,7 +31,6 @@ PYTHON_TO_SQL = {
     str: String,
     Literal: String,
     LiteralEx: String,
-    Enum: String,
     float: Float,
     bool: Boolean,
     datetime: DateTime,  # Note, list of datetime is not supported yet
@@ -46,7 +45,20 @@ def python_to_sql(typ):  # noqa: PLR0911
         if issubclass(typ, SQLType):
             return typ
         if issubclass(typ, Enum):
-            return str
+            value_types = {type(m.value) for m in typ}
+            if not value_types:
+                return String
+
+            sql_type = (
+                PYTHON_TO_SQL.get(value_types.pop()) if len(value_types) == 1 else None
+            )
+            if sql_type is None or sql_type in (Array, JSON):
+                raise TypeError(
+                    f"Cannot recognize type {typ}: enum member values"
+                    " must all be of one supported scalar type"
+                )
+
+            return sql_type
 
     res = PYTHON_TO_SQL.get(typ)
     if res:

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -105,7 +105,10 @@ def _list_to_array(typ, args):
     # Optional[scalar] elements map to a nullable Array element so None survives
     # (ClickHouse: Array(Nullable(T))).
     inner, is_optional = unwrap_optional(args0)
-    if is_optional and inner in NULLABLE_SCALARS:
+    if is_optional and (
+        inner in NULLABLE_SCALARS
+        or (inspect.isclass(inner) and issubclass(inner, Enum))
+    ):
         list_type = SQLType.as_nullable(list_type)
     return Array(list_type)
 

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -240,12 +240,12 @@ class CustomType(BaseModel):
 
 
 def _is_enum_annotation(annotation: Any) -> "TypeGuard[type[Enum]]":
-    # matches python_to_sql: an enum without canonical members maps to String,
+    # matches python_to_sql: an enum without members maps to String,
     # so its stored values stay raw
     return (
         isclass(annotation)
         and issubclass(annotation, Enum)
-        and next(iter(annotation), None) is not None
+        and bool(annotation.__members__)
     )
 
 

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -14,6 +14,7 @@ from collections.abc import (
 )
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from functools import cached_property
 from inspect import isclass
 from typing import (
@@ -1046,7 +1047,9 @@ class SignalSchema:
         type default: its base type is in ``NULLABLE_SCALARS`` and it is either an
         ``Optional[scalar]`` or sits under an ``Optional[DataModel]`` ancestor."""
         inner, is_optional = unwrap_optional(anno)
-        if inner not in NULLABLE_SCALARS:
+        if inner not in NULLABLE_SCALARS and not (
+            isclass(inner) and issubclass(inner, Enum)
+        ):
             return False
         return is_optional or self.optional_parent_sentinel(db_col) is not None
 

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -23,6 +23,7 @@ from typing import (
     Any,
     Final,
     Optional,
+    TypeGuard,
     Union,
     get_args,
     get_origin,
@@ -236,6 +237,16 @@ class CustomType(BaseModel):
             }
 
         return cls(**data)
+
+
+def _is_enum_annotation(annotation: Any) -> "TypeGuard[type[Enum]]":
+    # matches python_to_sql: an enum without canonical members maps to String,
+    # so its stored values stay raw
+    return (
+        isclass(annotation)
+        and issubclass(annotation, Enum)
+        and next(iter(annotation), None) is not None
+    )
 
 
 def create_feature_model(
@@ -708,7 +719,7 @@ class SignalSchema:
             if is_tuple_annotation(annotation):
                 return bool(parts)
             return any(cls._requires_row_conversion(part) for part in parts)
-        return False
+        return _is_enum_annotation(annotation)
 
     @staticmethod
     def _annotation_contains_type(annotation: Any, target: type) -> bool:
@@ -918,6 +929,9 @@ class SignalSchema:
             annotation = inner
             origin = get_origin(annotation)
 
+        if _is_enum_annotation(annotation):
+            return annotation(value)
+
         if ModelStore.is_pydantic(annotation):
             if isinstance(value, annotation):
                 obj = value
@@ -956,16 +970,11 @@ class SignalSchema:
                 decode_keys = key_needs_json_decode(key_type)
                 result = {}
                 for key, val in value.items():
-                    converted_key = key
-                    if decode_keys:
-                        try:
-                            converted_key = self._convert_feature_value(
-                                key_type, json.loads(key), catalog, cache
-                            )
-                        except ValueError:
-                            # Declared type and stored key disagree; keep the raw key
-                            # rather than failing the whole row.
-                            converted_key = key
+                    converted_key = (
+                        self._convert_mapping_key(key_type, key, catalog, cache)
+                        if decode_keys
+                        else key
+                    )
                     converted_val = (
                         self._convert_feature_value(val_type, val, catalog, cache)
                         if val_type is not Any
@@ -974,6 +983,22 @@ class SignalSchema:
                     result[converted_key] = converted_val
 
         return result
+
+    def _convert_mapping_key(
+        self,
+        key_type: DataType,
+        key: str,
+        catalog: "Catalog | None",
+        cache: bool,
+    ) -> Any:
+        try:
+            return self._convert_feature_value(
+                key_type, json.loads(key), catalog, cache
+            )
+        except ValueError:
+            # Declared type and stored key disagree; keep the raw key
+            # rather than failing the whole row.
+            return key
 
     @staticmethod
     def _set_file_stream(

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -3690,15 +3690,19 @@ def test_enum_fields_in_data_model(test_session):
     class Pet(BaseModel):
         species: Species
         rank: Rank
+        breed: Species | None
         tags: list[Species]
         grades: list[Grade]
+        marks: list[Grade | None]
 
     chain = dc.read_values(id=[1, 2], session=test_session).map(
         pet=lambda id: Pet(
             species=Species.CAT if id == 1 else Species.DOG,
             rank=Rank.FIRST if id == 1 else Rank.SECOND,
+            breed=Species.CAT if id == 1 else None,
             tags=[Species.CAT, Species.DOG],
             grades=[Grade.LOW, Grade.HIGH],
+            marks=[Grade.LOW, None],
         ),
         output=Pet,
     )
@@ -3708,21 +3712,28 @@ def test_enum_fields_in_data_model(test_session):
     schema = dataset.get_version("1.0.0").schema
     assert schema["pet__species"] == String
     assert schema["pet__rank"] == Int64
+    assert isinstance(schema["pet__breed"], String)
+    assert schema["pet__breed"].dc_nullable
     assert isinstance(schema["pet__tags"], Array)
     assert isinstance(schema["pet__grades"], Array)
+    assert schema["pet__marks"].item_type.dc_nullable
 
     expected = [
         Pet(
             species=Species.CAT,
             rank=Rank.FIRST,
+            breed=Species.CAT,
             tags=[Species.CAT, Species.DOG],
             grades=[Grade.LOW, Grade.HIGH],
+            marks=[Grade.LOW, None],
         ),
         Pet(
             species=Species.DOG,
             rank=Rank.SECOND,
+            breed=None,
             tags=[Species.CAT, Species.DOG],
             grades=[Grade.LOW, Grade.HIGH],
+            marks=[Grade.LOW, None],
         ),
     ]
     ds = dc.read_dataset("enum-model", session=test_session).order_by("id")

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1,4 +1,5 @@
 import datetime
+import enum
 import io
 import json
 import math
@@ -44,7 +45,7 @@ from datachain.lib.signal_schema import (
 from datachain.lib.udf import UDFAdapter
 from datachain.lib.udf_signature import UdfSignatureError
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
-from datachain.sql.types import Float, Int64, String
+from datachain.sql.types import Array, Float, Int64, String
 from datachain.utils import STUDIO_URL
 from tests.utils import (
     ANY_VALUE,
@@ -3671,6 +3672,66 @@ def test_mutate_with_composed_func_expression(test_session):
     )
     # "a" + ".csv" = 5, "hello" + ".csv" = 9, "readme" + ".csv" = 10
     assert result == [5, 9, 10]
+
+
+def test_enum_fields_in_data_model(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Rank(enum.Enum):
+        FIRST = 1
+        SECOND = 2
+
+    class Grade(enum.IntEnum):
+        LOW = 1
+        HIGH = 2
+
+    class Pet(BaseModel):
+        species: Species
+        rank: Rank
+        tags: list[Species]
+        grades: list[Grade]
+
+    chain = dc.read_values(id=[1, 2], session=test_session).map(
+        pet=lambda id: Pet(
+            species=Species.CAT if id == 1 else Species.DOG,
+            rank=Rank.FIRST if id == 1 else Rank.SECOND,
+            tags=[Species.CAT, Species.DOG],
+            grades=[Grade.LOW, Grade.HIGH],
+        ),
+        output=Pet,
+    )
+    chain.save("enum-model")
+
+    dataset = test_session.catalog.get_dataset("enum-model", versions=None)
+    schema = dataset.get_version("1.0.0").schema
+    assert schema["pet__species"] == String
+    assert schema["pet__rank"] == Int64
+    assert isinstance(schema["pet__tags"], Array)
+    assert isinstance(schema["pet__grades"], Array)
+
+    expected = [
+        Pet(
+            species=Species.CAT,
+            rank=Rank.FIRST,
+            tags=[Species.CAT, Species.DOG],
+            grades=[Grade.LOW, Grade.HIGH],
+        ),
+        Pet(
+            species=Species.DOG,
+            rank=Rank.SECOND,
+            tags=[Species.CAT, Species.DOG],
+            grades=[Grade.LOW, Grade.HIGH],
+        ),
+    ]
+    ds = dc.read_dataset("enum-model", session=test_session).order_by("id")
+    assert ds.to_values("pet") == expected
+
+    filtered = ds.filter(dc.C("pet.rank") == Rank.SECOND.value).order_by(
+        "pet.species", descending=True
+    )
+    assert filtered.to_values("pet") == [expected[1]]
 
 
 @skip_if_not_sqlite

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -3810,6 +3810,23 @@ def test_enum_leaf_read_inside_annotated(test_session):
     assert ds.to_values("pet.tags") == [[Species.CAT]]
 
 
+def test_zero_only_flag_field_round_trips(test_session):
+    class Flags(enum.IntFlag):
+        NONE = 0
+
+    class M(BaseModel):
+        f: Flags
+
+    dc.read_values(id=[1], session=test_session).map(
+        m=lambda id: M(f=Flags.NONE), output=M
+    ).save("enum-zero-flag")
+
+    ds = dc.read_dataset("enum-zero-flag", session=test_session)
+    dataset = test_session.catalog.get_dataset("enum-zero-flag", versions=None)
+    assert dataset.get_version("1.0.0").schema["m__f"] == Int64
+    assert ds.to_values("m.f") == [Flags.NONE]
+
+
 def test_enum_leaf_read_ignores_use_enum_values(test_session):
     class Species(enum.Enum):
         CAT = "cat"

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -5,9 +5,11 @@ import json
 import math
 import os
 import re
+import sqlite3
 import uuid
 from collections import Counter
 from collections.abc import Generator, Iterator
+from typing import Annotated
 from unittest.mock import ANY, patch
 
 import numpy as np
@@ -15,7 +17,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 import datachain as dc
 import datachain.query.dataset as query_dataset
@@ -37,10 +39,12 @@ from datachain.lib.dc.listings import read_listing_dataset
 from datachain.lib.file import File
 from datachain.lib.listing import LISTING_PREFIX, parse_listing_uri
 from datachain.lib.listing_info import ListingInfo
+from datachain.lib.model_store import ModelStore
 from datachain.lib.signal_schema import (
     SignalResolvingError,
     SignalResolvingTypeError,
     SignalSchema,
+    SignalSchemaWarning,
 )
 from datachain.lib.udf import UDFAdapter
 from datachain.lib.udf_signature import UdfSignatureError
@@ -3743,6 +3747,408 @@ def test_enum_fields_in_data_model(test_session):
         "pet.species", descending=True
     )
     assert filtered.to_values("pet") == [expected[1]]
+
+
+def test_enum_leaf_reads_return_members(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Rank(enum.IntEnum):
+        FIRST = 1
+        SECOND = 2
+
+    class Pet(BaseModel):
+        species: Species
+        rank: Rank
+        breed: Species | None
+        tags: list[Species]
+        scores: dict[str, Rank]
+
+    chain = dc.read_values(id=[1, 2], session=test_session).map(
+        pet=lambda id: Pet(
+            species=Species.CAT if id == 1 else Species.DOG,
+            rank=Rank.FIRST if id == 1 else Rank.SECOND,
+            breed=Species.CAT if id == 1 else None,
+            tags=[Species.CAT, Species.DOG],
+            scores={"a": Rank.FIRST},
+        ),
+        output=Pet,
+    )
+    chain.save("enum-leaves")
+
+    ds = dc.read_dataset("enum-leaves", session=test_session).order_by("id")
+    assert ds.to_values("pet.species") == [Species.CAT, Species.DOG]
+    assert ds.to_values("pet.breed") == [Species.CAT, None]
+    assert ds.to_values("pet.tags") == [[Species.CAT, Species.DOG]] * 2
+
+    ranks = ds.to_values("pet.rank")
+    assert ranks == [Rank.FIRST, Rank.SECOND]
+    assert all(isinstance(r, Rank) for r in ranks)
+
+    scores = ds.to_values("pet.scores")
+    assert scores == [{"a": Rank.FIRST}] * 2
+    assert all(isinstance(v, Rank) for s in scores for v in s.values())
+
+
+@pytest.mark.xfail(
+    reason="#1918: Annotated annotations are not normalized on the read path",
+    strict=True,
+)
+def test_enum_leaf_read_inside_annotated(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+
+    class Pet(BaseModel):
+        tags: list[Annotated[Species, "meta"]]
+
+    dc.read_values(id=[1], session=test_session).map(
+        pet=lambda id: Pet(tags=[Species.CAT]), output=Pet
+    ).save("enum-annotated")
+
+    ds = dc.read_dataset("enum-annotated", session=test_session)
+    assert ds.to_values("pet.tags") == [[Species.CAT]]
+
+
+def test_enum_leaf_read_ignores_use_enum_values(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Pet(BaseModel):
+        model_config = ConfigDict(use_enum_values=True)
+        species: Species
+
+    dc.read_values(id=[1, 2], session=test_session).map(
+        pet=lambda id: Pet(species=Species.CAT), output=Pet
+    ).save("enum-uev")
+
+    ds = dc.read_dataset("enum-uev", session=test_session)
+    assert [p.species for p in ds.to_values("pet")] == ["cat", "cat"]
+    assert ds.to_values("pet.species") == [Species.CAT, Species.CAT]
+
+
+def test_enum_leaf_through_ops(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Grade(enum.IntEnum):
+        LOW = 1
+        HIGH = 2
+
+    class Pet(BaseModel):
+        species: Species
+        grade: Grade
+        rank: int
+
+    chain = dc.read_values(id=[1, 2, 3], session=test_session).map(
+        pet=lambda id: Pet(
+            species=Species.CAT if id % 2 else Species.DOG,
+            grade=Grade.LOW if id % 2 else Grade.HIGH,
+            rank=id,
+        ),
+        output=Pet,
+    )
+    chain.save("enum-ops")
+    ds = dc.read_dataset("enum-ops", session=test_session)
+
+    assert ds.order_by("pet.species", "pet.rank").to_values("pet.species") == [
+        Species.CAT,
+        Species.CAT,
+        Species.DOG,
+    ]
+    assert ds.filter(dc.C("pet.species") == Species.CAT.value).to_values(
+        "pet.species"
+    ) == [Species.CAT, Species.CAT]
+    assert sorted(
+        ds.distinct("pet.species").to_values("pet.species"), key=lambda s: s.value
+    ) == [Species.CAT, Species.DOG]
+
+    top = ds.mutate(kind=dc.C("pet.species")).select("kind")
+    assert top.signals_schema.values["kind"] is Species
+    assert sorted(top.to_values("kind"), key=lambda s: s.value) == [
+        Species.CAT,
+        Species.CAT,
+        Species.DOG,
+    ]
+
+    labeled = ds.mutate(kind_alias=dc.C("pet.species").label("kind_alias"))
+    assert labeled.signals_schema.values["kind_alias"] is str
+    assert sorted(labeled.to_values("kind_alias")) == ["cat", "cat", "dog"]
+
+    composed = ds.mutate(g2=dc.C("pet.grade") + 1)
+    assert composed.signals_schema.values["g2"] is int
+    g2_values = sorted(composed.to_values("g2"))
+    assert g2_values == [2, 2, 3]
+    assert all(type(v) is int for v in g2_values)
+
+    counts = top.group_by(cnt=func.count(), partition_by="kind")
+    assert sorted(counts.to_list("kind", "cnt"), key=lambda t: t[0].value) == [
+        (Species.CAT, 2),
+        (Species.DOG, 1),
+    ]
+
+    window = func.window(partition_by="pet.species", order_by="pet.rank")
+    expected_firsts = [(1, Species.CAT), (2, Species.DOG), (3, Species.CAT)]
+    by_name = ds.mutate(first_kind=func.first("pet.species").over(window))
+    assert sorted(by_name.to_list("pet.rank", "first_kind")) == expected_firsts
+    by_slot = ds.mutate(first_kind=func.first(dc.C("pet.species")).over(window))
+    assert sorted(by_slot.to_list("pet.rank", "first_kind")) == expected_firsts
+
+
+def test_enum_leaf_through_set_ops(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Pet(BaseModel):
+        species: Species
+
+    def pets(ids, kinds):
+        return dc.read_values(id=ids, session=test_session).map(
+            pet=lambda id: Pet(species=Species(kinds[id])), output=Pet
+        )
+
+    left = pets([1, 2], {1: "cat", 2: "dog"})
+    right = pets([3], {3: "cat"})
+
+    assert sorted(
+        left.union(right).to_values("pet.species"), key=lambda s: s.value
+    ) == [Species.CAT, Species.CAT, Species.DOG]
+    assert sorted(
+        right.union(left).to_values("pet.species"), key=lambda s: s.value
+    ) == [Species.CAT, Species.CAT, Species.DOG]
+
+    assert left.subtract(right, on="pet.species").to_values("pet.species") == [
+        Species.DOG
+    ]
+
+    merged = left.merge(right, on="id", right_on="id").order_by("id")
+    assert merged.to_values("pet.species") == [Species.CAT, Species.DOG]
+
+    on_enum = left.merge(right, on="pet.species", inner=True)
+    assert on_enum.to_values("pet.species") == [Species.CAT]
+    assert on_enum.to_values("right_pet.species") == [Species.CAT]
+
+
+def test_enum_leaf_export_paths(tmp_dir, test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Pet(BaseModel):
+        species: Species
+
+    chain = (
+        dc.read_values(id=[1, 2], session=test_session)
+        .map(
+            pet=lambda id: Pet(species=Species.CAT if id == 1 else Species.DOG),
+            output=Pet,
+        )
+        .order_by("id")
+    )
+
+    assert [r["pet__species"] for r in chain.to_records()] == ["cat", "dog"]
+
+    df = chain.to_pandas()
+    species_cols = [c for c in df.columns if "species" in str(c)]
+    assert len(species_cols) == 1
+    assert df[species_cols[0]].tolist() == ["cat", "dog"]
+
+    parquet_path = tmp_dir / "pets.parquet"
+    chain.to_parquet(parquet_path)
+    out = pd.read_parquet(parquet_path)
+    parquet_cols = [c for c in out.columns if "species" in str(c)]
+    assert len(parquet_cols) == 1
+    assert sorted(out[parquet_cols[0]]) == ["cat", "dog"]
+
+    csv_path = tmp_dir / "pets.csv"
+    chain.to_csv(csv_path)
+    header = csv_path.read_text().splitlines()[0].split(",")
+    assert len(header) == len(set(header))
+    csv_df = pd.read_csv(csv_path)
+    csv_species = [c for c in csv_df.columns if "species" in c]
+    assert len(csv_species) == 1
+    assert csv_df[csv_species[0]].tolist() == ["cat", "dog"]
+
+    json_path = tmp_dir / "pets.json"
+    chain.to_json(json_path)
+    with open(json_path) as f:
+        values = json.load(f)
+    assert [v["pet"]["species"] for v in values] == ["cat", "dog"]
+
+    jsonl_path = tmp_dir / "pets.jsonl"
+    chain.to_jsonl(jsonl_path)
+    lines = [json.loads(line) for line in jsonl_path.read_text().splitlines()]
+    assert [v["pet"]["species"] for v in lines] == ["cat", "dog"]
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        chain.to_database("pets", conn)
+        rows = conn.execute("SELECT pet__species FROM pets").fetchall()
+        assert sorted(r[0] for r in rows) == ["cat", "dog"]
+    finally:
+        conn.close()
+
+
+def test_enum_leaf_adversarial_shapes(tmp_dir, test_session):
+    class Base(enum.Enum):
+        pass
+
+    class Species(Base):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Pet(BaseModel):
+        species: Species
+        maybe: Species | None
+        file: File
+
+    src = tmp_dir / "src"
+    src.mkdir()
+    (src / "a.txt").write_text("hello")
+
+    chain = dc.read_values(id=[1], session=test_session).map(
+        pet=lambda id: Pet(
+            species=Species.CAT,
+            maybe=None,
+            file=File(source=src.as_uri(), path="a.txt"),
+        ),
+        output=Pet,
+    )
+    chain.save("enum-adv")
+    ds = dc.read_dataset("enum-adv", session=test_session)
+
+    assert ds.to_values("pet.species") == [Species.CAT]
+    assert ds.to_values("pet.maybe") == [None]
+    assert ds.to_values("pet.file.path") == ["a.txt"]
+
+    empty = ds.filter(dc.C("id") == 999)
+    assert empty.to_values("pet.species") == []
+
+    out = tmp_dir / "out"
+    ds.to_storage(out, signal="pet.file", placement="filename")
+    assert (out / "a.txt").read_text() == "hello"
+
+
+def test_enum_as_udf_output_is_rejected(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+
+    with pytest.raises(UdfSignatureError, match="Species"):
+        dc.read_values(id=[1], session=test_session).map(
+            kind=lambda id: Species.CAT, output={"kind": Species}
+        )
+
+
+def test_enum_leaf_reads_degrade_when_enum_not_importable(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+
+    class PetEnumReload(BaseModel):
+        species: Species
+
+    dc.read_values(id=[1], session=test_session).map(
+        pet=lambda id: PetEnumReload(species=Species.CAT), output=PetEnumReload
+    ).save("enum-reload")
+
+    original = ModelStore.store.pop("PetEnumReload", None)
+    try:
+        with pytest.warns(SignalSchemaWarning, match="Species"):
+            ds = dc.read_dataset("enum-reload", session=test_session)
+            assert ds.to_values("pet.species") == ["cat"]
+            (pet,) = ds.to_values("pet")
+            assert pet.species == "cat"
+    finally:
+        if original is not None:
+            ModelStore.store["PetEnumReload"] = original
+        else:
+            ModelStore.store.pop("PetEnumReload", None)
+
+
+def test_same_name_enums_across_models(test_session):
+    class Kind(enum.Enum):
+        A = "a"
+
+    class M1(BaseModel):
+        kind: Kind
+
+    first_kind = Kind
+
+    class Kind(enum.Enum):
+        B = "b"
+
+    class M2(BaseModel):
+        kind: Kind
+
+    dc.read_values(id=[1], session=test_session).map(
+        m1=lambda id: M1(kind=first_kind.A), output=M1
+    ).save("enum-name-1")
+    dc.read_values(id=[1], session=test_session).map(
+        m2=lambda id: M2(kind=Kind.B), output=M2
+    ).save("enum-name-2")
+
+    assert dc.read_dataset("enum-name-1", session=test_session).to_values(
+        "m1.kind"
+    ) == [first_kind.A]
+    assert dc.read_dataset("enum-name-2", session=test_session).to_values(
+        "m2.kind"
+    ) == [Kind.B]
+
+
+def test_enum_leaf_as_udf_input(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Pet(BaseModel):
+        species: Species
+
+    chain = dc.read_values(id=[1, 2], session=test_session).map(
+        pet=lambda id: Pet(species=Species.CAT if id == 1 else Species.DOG),
+        output=Pet,
+    )
+    chain.save("enum-udf")
+    ds = dc.read_dataset("enum-udf", session=test_session).order_by("id")
+
+    def mapper(species):
+        assert isinstance(species, Species)
+        return species.value
+
+    assert sorted(
+        ds.map(mout=mapper, params=["pet.species"], output=str).to_values("mout")
+    ) == ["cat", "dog"]
+
+    def generator(species):
+        assert isinstance(species, Species)
+        yield species.value
+
+    assert sorted(
+        ds.gen(gout=generator, params=["pet.species"], output=str).to_values("gout")
+    ) == ["cat", "dog"]
+
+    def aggregator(species):
+        assert all(isinstance(s, Species) for s in species)
+        yield ",".join(s.value for s in species)
+
+    assert sorted(
+        ds.agg(
+            aout=aggregator,
+            params=["pet.species"],
+            partition_by="pet.species",
+            output=str,
+        ).to_values("aout")
+    ) == ["cat", "dog"]
+
+    def multi(species):
+        assert isinstance(species, Species)
+        return species.value, len(species.value)
+
+    multi_ds = ds.map(
+        multi_out=multi, params=["pet.species"], output={"val": str, "length": int}
+    )
+    assert sorted(multi_ds.to_list("val", "length")) == [("cat", 3), ("dog", 3)]
 
 
 @skip_if_not_sqlite

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -1,10 +1,11 @@
+import enum
 from collections.abc import Mapping
 from typing import Dict, Literal  # noqa: UP035
 
 import pytest
 
 from datachain.lib.convert.python_to_sql import python_to_sql
-from datachain.sql.types import JSON, Array, Float, String
+from datachain.sql.types import JSON, Array, Float, Int64, String
 from tests.unit.lib.test_utils import MyModel
 
 
@@ -20,6 +21,7 @@ from tests.unit.lib.test_utils import MyModel
         (Dict, JSON),  # noqa: UP006
         (str | None, String),
         (dict | list[dict], JSON),
+        (enum.Enum, String),
     ),
     ids=[
         "str",
@@ -30,10 +32,66 @@ from tests.unit.lib.test_utils import MyModel
         "bare-typing-Dict",
         "optional-str",
         "dict-or-list-of-dict",
+        "enum",
     ],
 )
 def test_python_to_sql_conversions(typ, expected):
     assert python_to_sql(typ) == expected
+
+
+class IntKind(enum.Enum):
+    A = 1
+    B = 2
+
+
+class StrKind(enum.Enum):
+    A = "a"
+
+
+class StrMixinKind(str, enum.Enum):
+    A = "a"
+
+
+class FloatKind(enum.Enum):
+    A = 1.5
+
+
+class MixedKind(enum.Enum):
+    A = 1
+    B = "b"
+
+
+class ListValuedKind(enum.Enum):
+    A = [1, 2]  # noqa: RUF012
+
+
+class DictValuedKind(enum.Enum):
+    A = {"a": 1}  # noqa: RUF012
+
+
+class TupleValuedKind(enum.Enum):
+    A = (1, 2)
+
+
+@pytest.mark.parametrize(
+    "typ,expected",
+    (
+        (IntKind, Int64),
+        (StrKind, String),
+        (StrMixinKind, String),
+        (FloatKind, Float),
+    ),
+)
+def test_enum_value_type_mapping(typ, expected):
+    assert python_to_sql(typ) == expected
+
+
+@pytest.mark.parametrize(
+    "typ", (MixedKind, ListValuedKind, DictValuedKind, TupleValuedKind)
+)
+def test_enum_unsupported_value_types(typ):
+    with pytest.raises(TypeError, match="enum member values"):
+        python_to_sql(typ)
 
 
 def test_list_of_tuples_matching_types():

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1,7 +1,6 @@
 import enum
 import json
 import pickle
-import sys
 from collections import UserDict, UserList
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import datetime
@@ -1087,19 +1086,13 @@ def test_row_to_objs_leaves_memberless_enum_raw():
     assert converted == "cat"
 
 
-def test_row_to_objs_zero_only_flag_matches_column_mapping():
+def test_row_to_objs_converts_zero_only_flag():
     class Flags(enum.IntFlag):
         NONE = 0
 
-    # 3.11 stopped iterating zero-valued flag members, so python_to_sql maps
-    # this flag to String there and to Int64 on 3.10; conversion must agree
-    # with that mapping on both versions
-    if sys.version_info >= (3, 11):
-        (converted,) = SignalSchema({"x": Flags}).row_to_objs(("0",))
-        assert converted == "0"
-    else:
-        (converted,) = SignalSchema({"x": Flags}).row_to_objs((0,))
-        assert converted is Flags.NONE
+    (converted,) = SignalSchema({"x": Flags}).row_to_objs((0,))
+
+    assert converted is Flags.NONE
 
 
 def test_row_to_features_does_not_decode_string_keys(test_session):

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1,3 +1,4 @@
+import enum
 import json
 import pickle
 from collections import UserDict, UserList
@@ -1060,6 +1061,38 @@ def test_row_to_objs_dict_key_decoding_policy(key_type, raw, expected):
     (converted,) = SignalSchema({"m": dict[key_type, int]}).row_to_objs((raw,))
 
     assert converted == expected
+
+
+def test_row_to_objs_converts_enum_leaf():
+    class Species(enum.Enum):
+        CAT = "cat"
+
+    (converted,) = SignalSchema({"x": Species}).row_to_objs(("cat",))
+
+    assert converted is Species.CAT
+
+
+def test_row_to_objs_unknown_enum_value_raises():
+    class Species(enum.Enum):
+        CAT = "cat"
+
+    with pytest.raises(ValueError, match="bogus"):
+        SignalSchema({"x": Species}).row_to_objs(("bogus",))
+
+
+def test_row_to_objs_leaves_memberless_enum_raw():
+    (converted,) = SignalSchema({"x": enum.Enum}).row_to_objs(("cat",))
+
+    assert converted == "cat"
+
+
+def test_row_to_objs_leaves_zero_only_flag_raw():
+    class Flags(enum.IntFlag):
+        NONE = 0
+
+    (converted,) = SignalSchema({"x": Flags}).row_to_objs(("0",))
+
+    assert converted == "0"
 
 
 def test_row_to_features_does_not_decode_string_keys(test_session):

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1,6 +1,7 @@
 import enum
 import json
 import pickle
+import sys
 from collections import UserDict, UserList
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import datetime
@@ -1086,13 +1087,19 @@ def test_row_to_objs_leaves_memberless_enum_raw():
     assert converted == "cat"
 
 
-def test_row_to_objs_leaves_zero_only_flag_raw():
+def test_row_to_objs_zero_only_flag_matches_column_mapping():
     class Flags(enum.IntFlag):
         NONE = 0
 
-    (converted,) = SignalSchema({"x": Flags}).row_to_objs(("0",))
-
-    assert converted == "0"
+    # 3.11 stopped iterating zero-valued flag members, so python_to_sql maps
+    # this flag to String there and to Int64 on 3.10; conversion must agree
+    # with that mapping on both versions
+    if sys.version_info >= (3, 11):
+        (converted,) = SignalSchema({"x": Flags}).row_to_objs(("0",))
+        assert converted == "0"
+    else:
+        (converted,) = SignalSchema({"x": Flags}).row_to_objs((0,))
+        assert converted is Flags.NONE
 
 
 def test_row_to_features_does_not_decode_string_keys(test_session):

--- a/tests/unit/test_warehouse.py
+++ b/tests/unit/test_warehouse.py
@@ -1,4 +1,5 @@
 import base64
+import enum
 import json
 from unittest.mock import patch
 
@@ -9,6 +10,7 @@ import datachain as dc
 from datachain.data_storage.serializer import deserialize
 from datachain.data_storage.sqlite import SQLiteWarehouse
 from datachain.lib.file import File
+from datachain.sql.types import Array, Float, Int64, String
 
 
 def test_serialize(sqlite_db):
@@ -225,3 +227,58 @@ def test_select_node_fields_by_parent_path_tar_wildcards_are_literal(
         "dir_%1/b.csv",
         "dir_%1/nested/c.csv",
     ]
+
+
+class IntGrade(enum.IntEnum):
+    LOW = 1
+    HIGH = 2
+
+
+class StrMixinKind(str, enum.Enum):
+    A = "a"
+
+
+class PlainKind(enum.Enum):
+    X = "x"
+
+
+@pytest.mark.parametrize(
+    "val,col_type,expected",
+    (
+        ([1, IntGrade.HIGH], Array(Int64), [1, 2]),
+        ([IntGrade.LOW, IntGrade.HIGH], Array(Int64), [1, 2]),
+        ([StrMixinKind.A, "b"], Array(String), ["a", "b"]),
+        ([PlainKind.X], Array(String), ["x"]),
+        ([1, IntGrade.HIGH], Array(Float), [1.0, 2.0]),
+        (IntGrade.HIGH, Int64(), 2),
+        (StrMixinKind.A, String(), "a"),
+    ),
+)
+def test_convert_type_unwraps_enums(sqlite_db, val, col_type, expected):
+    warehouse = SQLiteWarehouse(sqlite_db)
+    python_type = list if isinstance(val, list) else type(expected)
+    converted = warehouse.convert_type(
+        val, col_type, python_type, type(col_type).__name__, "col"
+    )
+    assert converted == expected
+    if isinstance(converted, list):
+        assert [type(i) for i in converted] == [type(i) for i in expected]
+    else:
+        assert type(converted) is type(expected)
+
+
+@pytest.mark.parametrize(
+    "val,col_type",
+    (
+        ([1, PlainKind.X], Array(Int64)),
+        (["a", IntGrade.HIGH], Array(String)),
+        (PlainKind.X, Int64()),
+    ),
+)
+def test_convert_type_validates_unwrapped_enums(sqlite_db, val, col_type):
+    warehouse = SQLiteWarehouse(sqlite_db)
+    python_type = list if isinstance(val, list) else int
+    with pytest.raises(ValueError, match="incompatible for column type"):
+        warehouse.convert_type(
+            val, col_type, python_type, type(col_type).__name__, "col"
+        )


### PR DESCRIPTION
## Problem

`python_to_sql` returned Python’s built-in `str` for Enum subclasses. DataChain expects a SQLAlchemy type, so creating a column for an enum-typed signal failed:

```python
class Species(enum.Enum):
    CAT = "cat"
    DOG = "dog"


class Pet(BaseModel):
    species: Species


chain = dc.read_values(id=[1, 2]).map(
    pet=lambda id: Pet(species=Species.CAT),
    output=Pet,
)
chain.save("pets")
```

Before this change, `save()` raised:

```text
AttributeError: type object 'str' has no attribute '_set_parent_with_dispatch'
```

## Fix

Enum subclasses now map to SQL types through the existing `PYTHON_TO_SQL` mapping, based on their member values:

- `int` values → `Int64`
- `str` values → `String`
- `float` values → `Float`

All members must have the same supported scalar value type. Enums with mixed or container values raise `TypeError` during schema construction because they cannot be represented by one scalar SQL type and reconstructed reliably by Pydantic.

Bare `Enum` annotations continue to map to `String`. The obsolete `Enum: String` table entry was removed because enum classes are handled before the table lookup.

On write, `AbstractWarehouse.convert_type` unwraps `Enum.value` before validation. This applies to scalar fields and Enum members inside arrays, including `str`- and `int`-mixin enums. Array elements receive the normal validation and coercion:

```python
[1, Grade.HIGH]    # Array(Int64) → [1, 2]     (was [1, Grade.HIGH])
[1.5, Grade.HIGH]  # Array(Float) → [1.5, 2.0] (was [1.5, Grade.HIGH])
[1, TextKind.X]    # Array(Int64) → ValueError (was [1, TextKind.X])
```

## Result

Enum fields now round-trip through models end to end:

- `save()` writes the underlying member values.
- Dataset schemas record the mapped SQL types.
- Reads reconstruct the Enum members through Pydantic.
- Scalar and `list[Enum]` fields work with `filter()` and `order_by()`.

Verified on SQLite and ClickHouse; the DataChain test suite runs against ClickHouse in the SaaS repository’s CI.

This was discovered while fixing `mutate()` schema recording, where an enum-typed SQL expression reached the same built-in-`str` path.

**Update:** this PR now also covers the read side. `SignalSchema._convert_feature_value` reconstructs enum members when reading leaf signals, so `to_values("pet.species")`, `list[Enum]`, and `dict[str, Enum]` values return members instead of raw `str`/`int` (whole-model reads already did via pydantic). An unknown stored value raises `ValueError`, matching whole-model behavior; a memberless enum (e.g. zero-only `IntFlag`) maps to `String` and stays raw, matching `python_to_sql`. Tests follow the AGENT.md signal→column matrix: every op, set ops, each export path, UDF input shapes, adversarial type shapes, and schema-reload degradation. Known gaps pinned to #1918 by strict xfail: `Annotated` normalization and string-valued enum mapping keys.

<sub>🤖 Co-authored by Claude Code and ChatGPT</sub>