### PR TITLE
Tolerate double-encoded arrays in LLM structured list output

### DIFF
--- a/src/datachain/llm/engine.py
+++ b/src/datachain/llm/engine.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError, create_model
 
+from datachain import json
 from datachain.lib.utils import DataChainError
 from datachain.llm.types import Usage
 
@@ -131,6 +132,17 @@ def parse_list(item_type: type, content: str) -> list:
         except ValidationError:
             try:
                 return adapter.validate_json(candidate)  # bare top-level array
+            except ValidationError as exc:
+                last_error = exc
+
+        # some models double-encode: {"items": "<the array as a JSON string>"}
+        try:
+            items = json.loads(candidate).get("items")
+        except (ValueError, AttributeError):
+            items = None
+        if isinstance(items, str):
+            try:
+                return adapter.validate_json(items)
             except ValidationError as exc:
                 last_error = exc
     raise LLMError(

--- a/tests/unit/lib/test_llm.py
+++ b/tests/unit/lib/test_llm.py
@@ -230,6 +230,12 @@ def test_list_schema_tolerates_double_encoded_items(fake_llm):
     assert [c.text for c in out] == ["a", "b"]
 
 
+def test_list_schema_raises_on_invalid_double_encoded_items(fake_llm):
+    fake_llm.structured_overrides["LLMListOutput"] = '{"items": "[{\\"nope\\": 1}]"}'
+    with pytest.raises(engine.LLMError, match=r"list\[Chunk\]"):
+        bind(llm.complete("t", schema=list[Chunk], retries=0), llm="m")("doc")
+
+
 def test_list_schema_raises_on_unparsable_output(fake_llm):
     fake_llm.structured_overrides["LLMListOutput"] = "not a json list"
     with pytest.raises(engine.LLMError, match=r"list\[Chunk\]"):

--- a/tests/unit/lib/test_llm.py
+++ b/tests/unit/lib/test_llm.py
@@ -222,6 +222,14 @@ def test_list_schema_tolerates_bare_array_response(fake_llm):
     assert [c.text for c in out] == ["a", "b"]
 
 
+def test_list_schema_tolerates_double_encoded_items(fake_llm):
+    fake_llm.structured_overrides["LLMListOutput"] = (
+        '{"items": "[\\n  {\\"text\\": \\"a\\"},\\n  {\\"text\\": \\"b\\"}\\n]"}'
+    )
+    out = bind(llm.complete("t", schema=list[Chunk]), llm="m")("doc")
+    assert [c.text for c in out] == ["a", "b"]
+
+
 def test_list_schema_raises_on_unparsable_output(fake_llm):
     fake_llm.structured_overrides["LLMListOutput"] = "not a json list"
     with pytest.raises(engine.LLMError, match=r"list\[Chunk\]"):


### PR DESCRIPTION
The `examples (llm_and_nlp)` CI job [started failing](https://github.com/datachain-ai/datachain/actions/runs/32139066489/job/95733020589?pr=1929) deterministically: for `schema=list[Sentence]` on `anthropic/claude-haiku-4-5`, the model now returns the array double-encoded as a string inside the container field —

```json
{"items": "[\n  {\"text\": \"...\"}\n]"}
```

`parse_list` only tried two shapes (the proper `{items: [...]}` container and a bare top-level array), so this fell through to `LLMError: model output could not be parsed as list[Sentence]`. The failure is model-side drift, not a repo change — the example last changed in July, and reruns fail identically; litellm emulates structured output for Anthropic, and small models under that emulation sometimes serialize an array field as a JSON string.

`parse_list` now tries a third candidate: if the payload is an object whose `items` value is a string, that string is validated as the array — full pydantic validation still applies to the recovered content, so garbage still raises `LLMError`. Applies to fence-wrapped output too. This extends the parser's existing best-effort ladder (markdown-fence stripping, bare-array acceptance) rather than adding a new leniency mechanism.

The new unit test reproduces the failing payload's shape — the array double-encoded as a multiline JSON string in `items` — against the same parse path.

<sub>Co-authored by Claude Code and ChatGPT</sub>