### PR TITLE
Fix array element validation

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -162,26 +162,31 @@ class AbstractWarehouse(ABC, Serializable):
                 col_name,
             )
 
+            item_nullable = getattr(col_type.item_type, "dc_nullable", False)
+
             if item_python_type is not list:
-                if isinstance(val[0], item_python_type):
+                if all(
+                    (i is None and item_nullable)
+                    or (isinstance(i, item_python_type) and not isinstance(i, Enum))
+                    for i in val
+                ):
                     # SQLite ARRAY storage expects a list; tuples/sets must be
                     # converted to lists even when element types already match.
-                    # Enum elements go through full conversion for validation.
-                    return [
-                        self.convert_type(i, *item_type_info)
-                        if isinstance(i, Enum)
-                        else i
-                        for i in val
-                    ]
-                if item_python_type is float and isinstance(val[0], int):
-                    return [
-                        self.convert_type(i, *item_type_info)
-                        if isinstance(i, Enum)
-                        else float(i)
-                        for i in val
-                    ]
+                    # None stays NULL in nullable arrays.
+                    return list(val)
+                if item_python_type is float and all(
+                    (i is None and item_nullable)
+                    or (isinstance(i, int) and not isinstance(i, Enum))
+                    for i in val
+                ):
+                    return [None if i is None else float(i) for i in val]
 
-            return [self.convert_type(i, *item_type_info) for i in val]
+            return [
+                None
+                if i is None and item_nullable
+                else self.convert_type(i, *item_type_info)
+                for i in val
+            ]
 
         # Special use case with JSON type as we save it as string
         if col_python_type is dict or col_type_name == "JSON":

--- a/tests/unit/test_warehouse.py
+++ b/tests/unit/test_warehouse.py
@@ -10,7 +10,7 @@ import datachain as dc
 from datachain.data_storage.serializer import deserialize
 from datachain.data_storage.sqlite import SQLiteWarehouse
 from datachain.lib.file import File
-from datachain.sql.types import Array, Float, Int64, String
+from datachain.sql.types import Array, Float, Int64, SQLType, String
 
 
 def test_serialize(sqlite_db):
@@ -250,11 +250,16 @@ class PlainKind(enum.Enum):
         ([StrMixinKind.A, "b"], Array(String), ["a", "b"]),
         ([PlainKind.X], Array(String), ["x"]),
         ([1, IntGrade.HIGH], Array(Float), [1.0, 2.0]),
+        ([1, 2.5], Array(Float), [1.0, 2.5]),
+        ([True, 1], Array(Int64), [True, 1]),
+        ([1.0, None], Array(SQLType.as_nullable(Float)), [1.0, None]),
+        ([1, None], Array(SQLType.as_nullable(Float)), [1.0, None]),
+        ([None, 1.0], Array(SQLType.as_nullable(Float)), [None, 1.0]),
         (IntGrade.HIGH, Int64(), 2),
         (StrMixinKind.A, String(), "a"),
     ),
 )
-def test_convert_type_unwraps_enums(sqlite_db, val, col_type, expected):
+def test_convert_type_conversions(sqlite_db, val, col_type, expected):
     warehouse = SQLiteWarehouse(sqlite_db)
     python_type = list if isinstance(val, list) else type(expected)
     converted = warehouse.convert_type(
@@ -273,9 +278,16 @@ def test_convert_type_unwraps_enums(sqlite_db, val, col_type, expected):
         ([1, PlainKind.X], Array(Int64)),
         (["a", IntGrade.HIGH], Array(String)),
         (PlainKind.X, Int64()),
+        ([StrMixinKind.A, 1], Array(String)),
+        (["a", 1], Array(String)),
+        ([1, "a"], Array(Int64)),
+        ([1, "a"], Array(Float)),
+        ([None, 1.0], Array(Float)),
+        ([1.0, None], Array(Float)),
+        ([1, None], Array(Float)),
     ),
 )
-def test_convert_type_validates_unwrapped_enums(sqlite_db, val, col_type):
+def test_convert_type_rejects_incompatible_values(sqlite_db, val, col_type):
     warehouse = SQLiteWarehouse(sqlite_db)
     python_type = list if isinstance(val, list) else int
     with pytest.raises(ValueError, match="incompatible for column type"):


### PR DESCRIPTION
Follow-up to the [enum signal-type PR](https://github.com/datachain-ai/datachain/pull/1929), from review feedback there: `convert_type`'s array fast path decided compatibility from `val[0]` alone and trusted the rest, so a list like `[StrMixinKind.A, 1]` for `Array(String)` unwrapped the first element and passed the trailing `int` through unchanged.

The fast path now checks every element: a list is copied through only when all elements match the item type (enums excluded — they always go through full conversion), the int→float coercion applies only when all elements are ints, and everything else falls to per-element conversion, which raises the usual incompatible-type `ValueError` for mismatches.

`None` is allowed exactly where the item type is nullable (`dc_nullable`), in all three paths. Two behavior changes on top of the review ask, both in the error-instead-of-silently-wrong direction:

- heterogeneous lists that previously passed through silently (`["a", 1]` for `Array(String)`) now raise at write time;
- `None` in a non-nullable array (`[1.0, None]` for `Array(Float)`) now raises instead of storing a null that surfaced as a read-time surprise — while nullable arrays (`Array(Nullable(Float))`) accept `None` in any position, including `[None, ...]`, which previously failed when `None` came first.

Verified on SQLite and ClickHouse.

<sub>🤖 Co-authored by Claude Code and ChatGPT</sub>