### PR TITLE
Unwrap enum members in filter and mutate expressions

### DIFF
--- a/src/datachain/func/func.py
+++ b/src/datachain/func/func.py
@@ -535,6 +535,8 @@ class Func(Function):  # noqa: PLW1641
         sql_type: Any,
         label: str | None,
     ) -> Any:
+        from datachain.lib.signal_schema import unwrap_enum_binds
+
         result: Any = func_col
 
         if self.is_window:
@@ -555,6 +557,7 @@ class Func(Function):  # noqa: PLW1641
             )
 
         result.type = sql_type() if inspect.isclass(sql_type) else sql_type
+        result = unwrap_enum_binds(result)
 
         if col_name := self.get_col_name(label):
             result = result.label(col_name)

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -56,6 +56,7 @@ from datachain.lib.signal_schema import (
     SignalResolvingError,
     SignalResolvingTypeError,
     SignalSchema,
+    unwrap_enum_binds,
 )
 from datachain.lib.udf import (
     Aggregator,
@@ -1669,7 +1670,7 @@ class DataChain:
                         mutated[mutated_name] = signal
                 elif isinstance(value, Func):
                     # adding new signal
-                    mutated[name] = value.get_column(schema)
+                    mutated[name] = unwrap_enum_binds(value.get_column(schema))  # type: ignore[assignment]
                 elif isinstance(value, primitives):
                     val = literal(value)
                     val.type = python_to_sql(type(value))()

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1217,7 +1217,7 @@ class DataChain:
                     processed_partition_columns.append(column)
                 else:
                     # Assume it's already a ColumnExpr
-                    processed_partition_columns.append(col)
+                    processed_partition_columns.append(unwrap_enum_binds(col))
 
             processed_partition_by = processed_partition_columns
         else:
@@ -1670,7 +1670,7 @@ class DataChain:
                         mutated[mutated_name] = signal
                 elif isinstance(value, Func):
                     # adding new signal
-                    mutated[name] = unwrap_enum_binds(value.get_column(schema))  # type: ignore[assignment]
+                    mutated[name] = value.get_column(schema)  # type: ignore[assignment]
                 elif isinstance(value, primitives):
                     val = literal(value)
                     val.type = python_to_sql(type(value))()

--- a/src/datachain/lib/dc/utils.py
+++ b/src/datachain/lib/dc/utils.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql.visitors import iterate, replacement_traverse
 
 from datachain.func.base import Function
 from datachain.lib.data_model import DataModel, DataType
+from datachain.lib.signal_schema import unwrap_enum_binds
 from datachain.lib.utils import DataChainParamsError
 from datachain.query.schema import DEFAULT_DELIMITER, ColumnExpr
 from datachain.utils import getenv_bool
@@ -85,7 +86,9 @@ def resolve_columns(
 
         for arg in args:
             if isinstance(arg, Function):
-                resolved_args.append(arg.get_column(self.signals_schema))
+                resolved_args.append(
+                    unwrap_enum_binds(arg.get_column(self.signals_schema))
+                )
             elif isinstance(arg, ColumnExpr):
                 resolved_args.append(resolve_expr(arg))
             else:

--- a/src/datachain/lib/dc/utils.py
+++ b/src/datachain/lib/dc/utils.py
@@ -8,7 +8,6 @@ from sqlalchemy.sql.visitors import iterate, replacement_traverse
 
 from datachain.func.base import Function
 from datachain.lib.data_model import DataModel, DataType
-from datachain.lib.signal_schema import unwrap_enum_binds
 from datachain.lib.utils import DataChainParamsError
 from datachain.query.schema import DEFAULT_DELIMITER, ColumnExpr
 from datachain.utils import getenv_bool
@@ -86,9 +85,7 @@ def resolve_columns(
 
         for arg in args:
             if isinstance(arg, Function):
-                resolved_args.append(
-                    unwrap_enum_binds(arg.get_column(self.signals_schema))
-                )
+                resolved_args.append(arg.get_column(self.signals_schema))
             elif isinstance(arg, ColumnExpr):
                 resolved_args.append(resolve_expr(arg))
             else:

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -32,7 +32,13 @@ from typing import (
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 from pydantic import BaseModel, Field, ValidationError, create_model
 from sqlalchemy import Cast, asc, cast, desc, nulls_last
-from sqlalchemy.sql.elements import BinaryExpression, Grouping, Label
+from sqlalchemy.sql.elements import (
+    BinaryExpression,
+    BindParameter,
+    Grouping,
+    Label,
+)
+from sqlalchemy.sql.visitors import replacement_traverse
 
 from datachain import json
 from datachain.func import literal
@@ -1235,8 +1241,31 @@ class SignalSchema:
 
         dc.C("col") creates untyped columns (NullType). This method rebuilds the
         expression tree replacing them with typed columns so SQLAlchemy propagates
-        types correctly through operators.
+        types correctly through operators. Enum members in bind parameters are
+        unwrapped to their values, since DB drivers cannot bind enum instances.
         """
+
+        def unwrap_enum_bind(element, **_kwargs):
+            if not isinstance(element, BindParameter):
+                return None
+
+            value = element.value
+
+            if isinstance(value, Enum):
+                clone = element._clone()
+                clone.value = value.value
+                return clone
+
+            if isinstance(value, (list, tuple)) and any(
+                isinstance(v, Enum) for v in value
+            ):
+                clone = element._clone()
+                clone.value = [v.value if isinstance(v, Enum) else v for v in value]
+                return clone
+
+            return None
+
+        expr = replacement_traverse(expr, {}, unwrap_enum_bind)
 
         typed_cols = {
             c.name: c for c in self.db_signals(as_columns=True) if isinstance(c, Column)

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -38,7 +38,7 @@ from sqlalchemy.sql.elements import (
     Grouping,
     Label,
 )
-from sqlalchemy.sql.visitors import replacement_traverse
+from sqlalchemy.sql.visitors import iterate, replacement_traverse
 
 from datachain import json
 from datachain.func import literal
@@ -252,6 +252,41 @@ def _is_enum_annotation(annotation: Any) -> "TypeGuard[type[Enum]]":
         isclass(annotation)
         and issubclass(annotation, Enum)
         and next(iter(annotation), None) is not None
+    )
+
+
+def unwrap_enum_binds(expr: "ColumnExpr") -> "ColumnExpr":
+    """Return the expression with enum members in bind parameters unwrapped to
+    their values, since DB drivers cannot bind enum instances."""
+    enum_binds: dict[int, BindParameter] = {}
+    plain_binds: list[BindParameter] = []
+
+    for element in iterate(expr):
+        if not isinstance(element, BindParameter):
+            continue
+        value = element.value
+        if isinstance(value, Enum):
+            clone = element._clone()
+            clone.value = value.value
+            enum_binds[id(element)] = clone
+        elif isinstance(value, (list, tuple)) and any(
+            isinstance(v, Enum) for v in value
+        ):
+            clone = element._clone()
+            clone.value = [v.value if isinstance(v, Enum) else v for v in value]
+            enum_binds[id(element)] = clone
+        else:
+            plain_binds.append(element)
+
+    if not enum_binds:
+        return expr
+
+    # replacement_traverse clones visited bind params by default; stop_on
+    # preserves the ordinary ones so unique bind names stay unique.
+    return replacement_traverse(
+        expr,
+        {"stop_on": plain_binds},
+        lambda element, **_kwargs: enum_binds.get(id(element)),
     )
 
 
@@ -1245,27 +1280,7 @@ class SignalSchema:
         unwrapped to their values, since DB drivers cannot bind enum instances.
         """
 
-        def unwrap_enum_bind(element, **_kwargs):
-            if not isinstance(element, BindParameter):
-                return None
-
-            value = element.value
-
-            if isinstance(value, Enum):
-                clone = element._clone()
-                clone.value = value.value
-                return clone
-
-            if isinstance(value, (list, tuple)) and any(
-                isinstance(v, Enum) for v in value
-            ):
-                clone = element._clone()
-                clone.value = [v.value if isinstance(v, Enum) else v for v in value]
-                return clone
-
-            return None
-
-        expr = replacement_traverse(expr, {}, unwrap_enum_bind)
+        expr = unwrap_enum_binds(expr)
 
         typed_cols = {
             c.name: c for c in self.db_signals(as_columns=True) if isinstance(c, Column)

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -255,6 +255,21 @@ def _is_enum_annotation(annotation: Any) -> "TypeGuard[type[Enum]]":
     )
 
 
+def _unwrap_enum_value(value: Any) -> tuple[Any, bool]:
+    if isinstance(value, Enum):
+        return value.value, True
+
+    # a composite IN produces one bind whose value is a list of row tuples,
+    # so enum members can sit at any nesting depth
+    if isinstance(value, (list, tuple)):
+        pairs = [_unwrap_enum_value(v) for v in value]
+        if any(changed for _, changed in pairs):
+            items = [v for v, _ in pairs]
+            return (tuple(items) if isinstance(value, tuple) else items), True
+
+    return value, False
+
+
 def unwrap_enum_binds(expr: "ColumnExpr") -> "ColumnExpr":
     """Return the expression with enum bind parameters unwrapped to their values."""
     enum_binds: dict[int, BindParameter] = {}
@@ -264,14 +279,8 @@ def unwrap_enum_binds(expr: "ColumnExpr") -> "ColumnExpr":
         if not isinstance(element, BindParameter):
             continue
 
-        value = element.value
-        if isinstance(value, Enum):
-            unwrapped = value.value
-        elif isinstance(value, (list, tuple)) and any(
-            isinstance(v, Enum) for v in value
-        ):
-            unwrapped = [v.value if isinstance(v, Enum) else v for v in value]
-        else:
+        unwrapped, changed = _unwrap_enum_value(element.value)
+        if not changed:
             plain_binds.append(element)
             continue
 

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -256,27 +256,28 @@ def _is_enum_annotation(annotation: Any) -> "TypeGuard[type[Enum]]":
 
 
 def unwrap_enum_binds(expr: "ColumnExpr") -> "ColumnExpr":
-    """Return the expression with enum members in bind parameters unwrapped to
-    their values, since DB drivers cannot bind enum instances."""
+    """Return the expression with enum bind parameters unwrapped to their values."""
     enum_binds: dict[int, BindParameter] = {}
     plain_binds: list[BindParameter] = []
 
     for element in iterate(expr):
         if not isinstance(element, BindParameter):
             continue
+
         value = element.value
         if isinstance(value, Enum):
-            clone = element._clone()
-            clone.value = value.value
-            enum_binds[id(element)] = clone
+            unwrapped = value.value
         elif isinstance(value, (list, tuple)) and any(
             isinstance(v, Enum) for v in value
         ):
-            clone = element._clone()
-            clone.value = [v.value if isinstance(v, Enum) else v for v in value]
-            enum_binds[id(element)] = clone
+            unwrapped = [v.value if isinstance(v, Enum) else v for v in value]
         else:
             plain_binds.append(element)
+            continue
+
+        # _with_value clones with a fresh key, so repeated unwrapping of a
+        # shared expression cannot produce same-name unique binds.
+        enum_binds[id(element)] = element._with_value(unwrapped)
 
     if not enum_binds:
         return expr

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6131,3 +6131,44 @@ def test_count_after_limit_then_distinct(test_session, boundary_counter):
 
     assert chain.limit(4).distinct("session_id", "position").count() == 2
     boundary_counter.assert_count(1)
+
+
+def test_filter_and_mutate_by_enum_member(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Rank(enum.Enum):
+        FIRST = 1
+        SECOND = 2
+
+    class Pet(BaseModel):
+        species: Species
+        rank: Rank
+
+    dc.read_values(id=[1, 2], session=test_session).map(
+        pet=lambda id: Pet(
+            species=Species.CAT if id == 1 else Species.DOG,
+            rank=Rank.FIRST if id == 1 else Rank.SECOND,
+        ),
+        output=Pet,
+    ).save("enum-filter")
+
+    ds = dc.read_dataset("enum-filter", session=test_session)
+    assert ds.filter(dc.C("pet.species") == Species.DOG).to_values("id") == [2]
+    assert ds.filter(dc.C("pet.rank") != Rank.SECOND).to_values("id") == [1]
+    assert ds.filter(dc.C("pet.rank") < Rank.SECOND).to_values("id") == [1]
+    assert sorted(
+        ds.filter(dc.C("pet.species").in_([Species.CAT, Species.DOG])).to_values("id")
+    ) == [1, 2]
+    assert ds.filter(
+        (dc.C("pet.rank") == Rank.SECOND) & (dc.C("pet.species") == Species.DOG)
+    ).to_values("id") == [2]
+    assert sorted(
+        ds.filter(
+            (dc.C("pet.rank") == Rank.FIRST) | (dc.C("pet.species") == Species.DOG)
+        ).to_values("id")
+    ) == [1, 2]
+    assert ds.mutate(is_dog=dc.C("pet.species") == Species.DOG).order_by(
+        "id"
+    ).to_values("is_dog") == [False, True]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6169,6 +6169,12 @@ def test_filter_and_mutate_by_enum_member(test_session):
             (dc.C("pet.rank") == Rank.FIRST) | (dc.C("pet.species") == Species.DOG)
         ).to_values("id")
     ) == [1, 2]
+    assert ds.filter(
+        func.and_(dc.C("pet.species") == Species.DOG, dc.C("id") > 0)
+    ).to_values("id") == [2]
     assert ds.mutate(is_dog=dc.C("pet.species") == Species.DOG).order_by(
         "id"
     ).to_values("is_dog") == [False, True]
+    assert ds.mutate(
+        func_dog=func.and_(dc.C("pet.species") == Species.DOG, dc.C("id") > 0)
+    ).order_by("id").to_values("func_dog") == [False, True]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -17,6 +17,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+import sqlalchemy
 from pydantic import BaseModel, ConfigDict
 
 import datachain as dc
@@ -6178,3 +6179,62 @@ def test_filter_and_mutate_by_enum_member(test_session):
     assert ds.mutate(
         func_dog=func.and_(dc.C("pet.species") == Species.DOG, dc.C("id") > 0)
     ).order_by("id").to_values("func_dog") == [False, True]
+
+
+def test_enum_bind_unwrapping_across_operations(test_session):
+    class Code(enum.Enum):
+        ONE = 1
+        TWO = 2
+
+    class Item(BaseModel):
+        code: Code
+
+    dc.read_values(id=[1, 2], session=test_session).map(
+        item=lambda id: Item(code=Code.ONE if id == 1 else Code.TWO), output=Item
+    ).save("enum-binds")
+    ds = dc.read_dataset("enum-binds", session=test_session)
+
+    assert ds.filter(
+        sqlalchemy.tuple_(dc.C("item.code"), dc.C("id")).in_([(Code.TWO, 2)])
+    ).to_values("id") == [2]
+
+    grouped = ds.group_by(
+        cnt=func.count(),
+        partition_by=func.ifelse(dc.C("item.code") == Code.TWO, "two", "other"),
+    )
+    assert sorted((d["gr_0"], d["cnt"]) for d in grouped.to_records()) == [
+        ("other", 1),
+        ("two", 1),
+    ]
+
+    summed = ds.group_by(
+        s=func.sum(func.ifelse(dc.C("item.code") == Code.TWO, 1, 0)),
+        partition_by="id",
+    )
+    assert sorted(summed.to_values("s")) == [0, 1]
+
+    def count_codes(codes):
+        yield len(list(codes))
+
+    by_func = ds.agg(
+        n=count_codes,
+        params=["item.code"],
+        partition_by=func.ifelse(dc.C("item.code") == Code.TWO, "t", "o"),
+        output=int,
+    )
+    assert by_func.to_values("n") == [1, 1]
+
+    by_expr = ds.agg(
+        n=count_codes,
+        params=["item.code"],
+        partition_by=dc.C("item.code") == Code.TWO,
+        output=int,
+    )
+    assert by_expr.to_values("n") == [1, 1]
+
+    two_first = func.ifelse(dc.C("item.code") == Code.TWO, 0, 1)
+    assert ds.order_by(two_first, "id").to_values("id") == [2, 1]
+
+    window = func.window(partition_by="id", order_by="id")
+    windowed = ds.mutate(w=func.first(two_first).over(window))
+    assert sorted(windowed.to_values("w")) == [0, 1]


### PR DESCRIPTION
Follow-up to the [enum signal-type PRs](https://github.com/datachain-ai/datachain/pull/1929). Filtering by an enum member failed at query-parameter binding, because query parameters never pass through the warehouse value conversion — plain `Enum` members (string- or int-valued alike) reach the driver as enum instances:

```python
ds.filter(dc.C("pet.rank") == Rank.SECOND.value)  # worked
ds.filter(dc.C("pet.rank") == Rank.SECOND)
# sqlite3.ProgrammingError: Error binding parameter 1: type 'Rank' is not supported
```

`SignalSchema.enrich_expr_types` — which every filter and mutate expression already passes through — now unwraps enum-valued bind parameters to their `.value` before rebuilding typed columns. The unwrap is a full expression traversal, so it also covers members inside `in_([...])` lists and binds nested in `&`/`|` groups:

```python
ds.filter(dc.C("pet.species") == Species.DOG)
ds.filter(dc.C("pet.species").in_([Species.CAT, Species.DOG]))
ds.filter((dc.C("pet.rank") == Rank.SECOND) & (dc.C("pet.species") == Species.DOG))
ds.filter((dc.C("pet.rank") == Rank.FIRST) | (dc.C("pet.species") == Species.DOG))
ds.mutate(is_dog=dc.C("pet.species") == Species.DOG)
```

All verified on SQLite and ClickHouse.

<sub>🤖 Co-authored by Claude Code and ChatGPT</sub>