### PR TITLE
Fall back to the public Ubuntu mirror when the Azure apt mirror stalls

### DIFF
--- a/.github/workflows/tests-studio.yml
+++ b/.github/workflows/tests-studio.yml
@@ -104,7 +104,15 @@ jobs:
         working-directory: backend
         run: make update_datachain_deps "${{ env.BRANCH }}"
 
+      - name: Fail over apt mirrors on stalled connections
+        # The runner image already lists fallback mirrors in /etc/apt/apt-mirrors.txt
+        # (Azure first, then archive.ubuntu.com), but failover only fires on an
+        # error, and a stalled Azure mirror connection never becomes one without
+        # a timeout.
+        run: echo 'Acquire::http::Timeout "10";' | sudo tee /etc/apt/apt.conf.d/99-timeout
+
       - name: Install FFmpeg
+        timeout-minutes: 5
         run: |
           sudo apt update
           sudo apt install -y ffmpeg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
+      - name: Fail over apt mirrors on stalled connections
+        if: runner.os == 'Linux'
+        # The runner image already lists fallback mirrors in /etc/apt/apt-mirrors.txt
+        # (Azure first, then archive.ubuntu.com), but failover only fires on an
+        # error, and a stalled Azure mirror connection never becomes one without
+        # a timeout.
+        run: echo 'Acquire::http::Timeout "10";' | sudo tee /etc/apt/apt.conf.d/99-timeout
+
       - name: Setup PostgreSQL
         if: runner.os != 'Windows'
         uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee # v8
@@ -132,6 +140,7 @@ jobs:
 
       - name: Install FFmpeg on Ubuntu
         if: runner.os == 'Linux'
+        timeout-minutes: 5
         run: |
           sudo apt update
           sudo apt install -y ffmpeg
@@ -220,8 +229,17 @@ jobs:
           brew install ffmpeg
           echo 'DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib' >> "$GITHUB_ENV"
 
+      - name: Fail over apt mirrors on stalled connections
+        if: runner.os == 'Linux'
+        # The runner image already lists fallback mirrors in /etc/apt/apt-mirrors.txt
+        # (Azure first, then archive.ubuntu.com), but failover only fires on an
+        # error, and a stalled Azure mirror connection never becomes one without
+        # a timeout.
+        run: echo 'Acquire::http::Timeout "10";' | sudo tee /etc/apt/apt.conf.d/99-timeout
+
       - name: Install FFmpeg on Ubuntu
         if: runner.os == 'Linux'
+        timeout-minutes: 5
         run: |
           sudo apt update
           sudo apt install -y ffmpeg


### PR DESCRIPTION
## What

Since ~17:00 UTC today, jobs on `ubuntu-latest` runners randomly hang for hours on `apt` steps ("Install FFmpeg", and `action-setup-postgres` internally). The Azure-internal Ubuntu mirror (`azure.archive.ubuntu.com`) that GitHub's runner images use is partially down in a nasty way: connections stall silently instead of failing. Sibling matrix jobs running the identical step seconds apart pass fine, which is what points at the mirror rather than the code.

The runner image actually ships with mirror failover already configured: `/etc/apt/apt-mirrors.txt` lists the Azure mirror at priority 1 and Canonical's public `archive.ubuntu.com` / `security.ubuntu.com` as fallbacks, wired into apt via the `mirror+file:` method ([provisioning script](https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/configure-apt-sources.sh)). But failover only fires on an *error*, and apt has no default inactivity timeout — a silently stalled connection never becomes an error, so the fallback never triggers and the job sits until the 6-hour limit kills it.

## How

A step before the first apt user in each affected job (before `action-setup-postgres` in `datachain`, before the FFmpeg install in `examples` and Studio Tests) sets `Acquire::http::Timeout "10"` in `apt.conf.d`. A stalled fetch now errors after 10 seconds, and apt's existing failover pulls the file from the public mirror instead. Writing it to the system config (rather than passing `-o` flags) also covers apt calls inside third-party actions. apt's https options default to the http counterparts, so the https fallback mirrors are covered.

The Ubuntu FFmpeg steps additionally get `timeout-minutes: 5` as a backstop, turning any remaining hang into a fast red fail instead of a 6-hour stuck job.

<sub>🤖 Co-authored by Claude Code and ChatGPT</sub>