### PR TITLE
Classify enums as nullable scalars in func results and merge widening

### DIFF
--- a/src/datachain/func/func.py
+++ b/src/datachain/func/func.py
@@ -9,9 +9,9 @@ from sqlalchemy import cast as sa_cast
 from sqlalchemy.sql import func as sa_func
 from sqlalchemy.sql.elements import ColumnElement
 
-from datachain.lib.convert.python_to_sql import python_to_sql
+from datachain.lib.convert.python_to_sql import is_nullable_scalar, python_to_sql
 from datachain.lib.convert.sql_to_python import sql_to_python
-from datachain.lib.data_model import is_nullable_scalar, unwrap_optional
+from datachain.lib.data_model import unwrap_optional
 from datachain.lib.model_store import ModelStore
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
 from datachain.query.schema import DEFAULT_DELIMITER, Column, ColumnExpr, ColumnMeta

--- a/src/datachain/func/func.py
+++ b/src/datachain/func/func.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql.elements import ColumnElement
 
 from datachain.lib.convert.python_to_sql import python_to_sql
 from datachain.lib.convert.sql_to_python import sql_to_python
-from datachain.lib.data_model import NULLABLE_SCALARS, unwrap_optional
+from datachain.lib.data_model import is_nullable_scalar, unwrap_optional
 from datachain.lib.model_store import ModelStore
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
 from datachain.query.schema import DEFAULT_DELIMITER, Column, ColumnExpr, ColumnMeta
@@ -428,14 +428,14 @@ class Func(Function):  # noqa: PLW1641
         signals_schema: "SignalSchema | None",
         col_type: "DataType | None" = None,
     ) -> bool:
-        """Whether this func's result column may hold NULL: a result type in
-        NULLABLE_SCALARS over a nullable source."""
+        """Return whether this func's result column may hold NULL: a
+        nullable-scalar result type over a nullable source."""
         if signals_schema is None:
             return False
         if col_type is None:
             col_type = self.get_result_type(signals_schema)
         inner, _ = unwrap_optional(col_type)
-        return inner in NULLABLE_SCALARS and any(
+        return is_nullable_scalar(inner) and any(
             _source_is_nullable(c, signals_schema) for c in self._db_cols
         )
 

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel
 from typing_extensions import Literal as LiteralEx
 
 from datachain.lib.data_model import (
-    NULLABLE_SCALARS,
     is_mapping_annotation,
+    is_nullable_scalar,
     is_sequence_annotation,
     unwrap_optional,
 )
@@ -105,10 +105,7 @@ def _list_to_array(typ, args):
     # Optional[scalar] elements map to a nullable Array element so None survives
     # (ClickHouse: Array(Nullable(T))).
     inner, is_optional = unwrap_optional(args0)
-    if is_optional and (
-        inner in NULLABLE_SCALARS
-        or (inspect.isclass(inner) and issubclass(inner, Enum))
-    ):
+    if is_optional and is_nullable_scalar(inner):
         list_type = SQLType.as_nullable(list_type)
     return Array(list_type)
 

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -9,7 +9,6 @@ from typing_extensions import Literal as LiteralEx
 
 from datachain.lib.data_model import (
     is_mapping_annotation,
-    is_nullable_scalar,
     is_sequence_annotation,
     unwrap_optional,
 )
@@ -38,6 +37,17 @@ PYTHON_TO_SQL = {
     list: Array,
     dict: JSON,
 }
+
+
+def is_nullable_scalar(typ) -> bool:
+    try:
+        sql_type = python_to_sql(typ)
+    except TypeError:
+        return False
+
+    if inspect.isclass(sql_type):
+        return not issubclass(sql_type, (Array, JSON))
+    return not isinstance(sql_type, (Array, JSON))
 
 
 def python_to_sql(typ):  # noqa: PLR0911

--- a/src/datachain/lib/data_model.py
+++ b/src/datachain/lib/data_model.py
@@ -6,7 +6,6 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import datetime
-from enum import Enum
 from typing import Any, ClassVar, Union, get_args, get_origin
 
 from pydantic import AliasChoices, BaseModel, Field, create_model
@@ -226,13 +225,6 @@ def unwrap_optional(t: Any) -> tuple[Any, bool]:
 # real NULL. SQLite stores NaN as NULL, so a stored NaN reads back as None there
 # (the other backends keep them distinct); None itself is consistent everywhere.
 NULLABLE_SCALARS: "tuple[type, ...]" = (int, float, str, bool, bytes, datetime)
-
-
-def is_nullable_scalar(typ: "Any") -> bool:
-    """Return whether a type maps to a nullable scalar column."""
-    if typ in NULLABLE_SCALARS:
-        return True
-    return inspect.isclass(typ) and issubclass(typ, Enum)
 
 
 # _type_tag discriminator for Optional[DataModel]: this value marks the present arm.

--- a/src/datachain/lib/data_model.py
+++ b/src/datachain/lib/data_model.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import datetime
+from enum import Enum
 from typing import Any, ClassVar, Union, get_args, get_origin
 
 from pydantic import AliasChoices, BaseModel, Field, create_model
@@ -225,6 +226,14 @@ def unwrap_optional(t: Any) -> tuple[Any, bool]:
 # real NULL. SQLite stores NaN as NULL, so a stored NaN reads back as None there
 # (the other backends keep them distinct); None itself is consistent everywhere.
 NULLABLE_SCALARS: "tuple[type, ...]" = (int, float, str, bool, bytes, datetime)
+
+
+def is_nullable_scalar(typ: "Any") -> bool:
+    """Return whether a type maps to a nullable scalar column."""
+    if typ in NULLABLE_SCALARS:
+        return True
+    return inspect.isclass(typ) and issubclass(typ, Enum)
+
 
 # _type_tag discriminator for Optional[DataModel]: this value marks the present arm.
 OPTIONAL_PRESENT_TAG = 0

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -44,7 +44,7 @@ from datachain import json
 from datachain.func import literal
 from datachain.func.func import Func
 from datachain.lib.convert.flatten import is_optional_model
-from datachain.lib.convert.python_to_sql import python_to_sql
+from datachain.lib.convert.python_to_sql import is_nullable_scalar, python_to_sql
 from datachain.lib.convert.sql_to_python import sql_to_python
 from datachain.lib.convert.unflatten import (
     read_optional_sentinel,
@@ -57,7 +57,6 @@ from datachain.lib.data_model import (
     annotation_parts,
     compute_model_fingerprint,
     is_mapping_annotation,
-    is_nullable_scalar,
     is_sequence_annotation,
     is_tuple_annotation,
     key_needs_json_decode,

--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -51,13 +51,13 @@ from datachain.lib.convert.unflatten import (
     unflatten_to_json_pos,
 )
 from datachain.lib.data_model import (
-    NULLABLE_SCALARS,
     DataModel,
     DataType,
     DataValue,
     annotation_parts,
     compute_model_fingerprint,
     is_mapping_annotation,
+    is_nullable_scalar,
     is_sequence_annotation,
     is_tuple_annotation,
     key_needs_json_decode,
@@ -1119,13 +1119,11 @@ class SignalSchema:
         raise SignalResolvingError([col_name], "is not found")
 
     def is_nullable_column(self, db_col: str, anno: DataType) -> bool:
-        """Whether a scalar leaf stores real NULL (``dc_nullable``) instead of the
-        type default: its base type is in ``NULLABLE_SCALARS`` and it is either an
-        ``Optional[scalar]`` or sits under an ``Optional[DataModel]`` ancestor."""
+        """Return whether a scalar leaf stores real NULL (``dc_nullable``)
+        instead of the type default: its base type is a nullable scalar and it is
+        an ``Optional[scalar]`` or sits under an ``Optional[DataModel]`` ancestor."""
         inner, is_optional = unwrap_optional(anno)
-        if inner not in NULLABLE_SCALARS and not (
-            isclass(inner) and issubclass(inner, Enum)
-        ):
+        if not is_nullable_scalar(inner):
             return False
         return is_optional or self.optional_parent_sentinel(db_col) is not None
 
@@ -1459,7 +1457,7 @@ class SignalSchema:
         def _nullable(type_: DataType, nullable: bool) -> DataType:
             # widen scalars to Optional (collections/models can't be Nullable on CH)
             inner, is_optional = unwrap_optional(type_)
-            if not nullable or is_optional or inner not in NULLABLE_SCALARS:
+            if not nullable or is_optional or not is_nullable_scalar(inner):
                 return type_
             return type_ | None  # type: ignore[return-value]
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -9,7 +9,7 @@ import sqlite3
 import uuid
 from collections import Counter
 from collections.abc import Generator, Iterator
-from typing import Annotated
+from typing import Annotated, Literal
 from unittest.mock import ANY, patch
 
 import numpy as np
@@ -6320,6 +6320,44 @@ def test_merge_widens_enum_signal(test_session):
 
     assert merged.signals_schema.values["species"] == (Species | None)
     assert merged.to_list("id", "species") == [(1, "cat"), (2, None)]
+
+
+def test_optional_literal_field_is_nullable(test_session):
+    class Doc(BaseModel):
+        kind: Literal["text", "image"] | None
+        grp: str
+
+    window = func.window(partition_by="doc.grp", order_by="id")
+    dc.read_values(id=[1, 2], session=test_session).map(
+        doc=lambda id: Doc(kind=None, grp="g"),
+        output=Doc,
+    ).mutate(first_kind=func.first("doc.kind").over(window)).save("lit-model")
+
+    dataset = test_session.catalog.get_dataset("lit-model", versions=None)
+    schema = dataset.get_version("1.0.0").schema
+    assert schema["doc__kind"].dc_nullable
+    assert schema["first_kind"].dc_nullable
+
+    ds = dc.read_dataset("lit-model", session=test_session).order_by("id")
+    assert ds.to_values("doc") == [Doc(kind=None, grp="g"), Doc(kind=None, grp="g")]
+    assert ds.to_values("first_kind") == [None, None]
+
+
+def test_merge_widens_literal_signal(test_session):
+    class Doc(BaseModel):
+        kind: Literal["text", "image"]
+
+    left = dc.read_values(id=[1, 2], session=test_session)
+    right = (
+        dc.read_values(id=[1], session=test_session)
+        .map(doc=lambda id: Doc(kind="text"), output=Doc)
+        .mutate(kind=dc.C("doc.kind"))
+        .select("id", "kind")
+    )
+    merged = left.merge(right, on="id", full=True).order_by("id")
+
+    assert merged.signals_schema.values["kind"] == (Literal["text", "image"] | None)
+    assert merged.to_list("id", "kind") == [(1, "text"), (2, None)]
 
 
 def test_merge_on_enum_signal(test_session):

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6319,7 +6319,7 @@ def test_merge_widens_enum_signal(test_session):
     merged = left.merge(right, on="id", full=True).order_by("id")
 
     assert merged.signals_schema.values["species"] == (Species | None)
-    assert merged.to_list("id", "species") == [(1, "cat"), (2, None)]
+    assert merged.to_list("id", "species") == [(1, Species.CAT), (2, None)]
 
 
 def test_optional_literal_field_is_nullable(test_session):
@@ -6381,6 +6381,6 @@ def test_merge_on_enum_signal(test_session):
     merged = left.merge(right, on="species").order_by("id")
 
     assert merged.to_list("id", "species", "right_id") == [
-        (1, "cat", None),
-        (2, "dog", 10),
+        (1, Species.CAT, None),
+        (2, Species.DOG, 10),
     ]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6238,3 +6238,111 @@ def test_enum_bind_unwrapping_across_operations(test_session):
     window = func.window(partition_by="id", order_by="id")
     windowed = ds.mutate(w=func.first(two_first).over(window))
     assert sorted(windowed.to_values("w")) == [0, 1]
+
+
+def test_window_func_over_nullable_enum(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Pet(BaseModel):
+        breed: Species | None
+        grp: str
+
+    named = func.window(partition_by="pet.grp", order_by="id")
+    slotted = func.window(partition_by=dc.C("pet.grp"), order_by=dc.C("id"))
+    with pytest.warns(SignalSchemaWarning, match="'Species'"):
+        # all rows NULL: ClickHouse first_value skips NULLs, so a mixed
+        # partition reads back differently per backend
+        dc.read_values(id=[1, 2], session=test_session).map(
+            pet=lambda id: Pet(breed=None, grp="g"),
+            output=Pet,
+        ).mutate(
+            first_named=func.first("pet.breed").over(named),
+            first_slotted=func.first("pet.breed").over(slotted),
+        ).save("enum-window")
+
+        dataset = test_session.catalog.get_dataset("enum-window", versions=None)
+        schema = dataset.get_version("1.0.0").schema
+        assert schema["first_named"].dc_nullable
+        assert schema["first_slotted"].dc_nullable
+
+        ds = dc.read_dataset("enum-window", session=test_session).order_by("id")
+        assert ds.to_values("first_named") == [None, None]
+        assert ds.to_values("first_slotted") == [None, None]
+
+
+def test_composed_func_over_nullable_enum(test_session):
+    class Grade(enum.Enum):
+        LOW = 1
+        HIGH = 2
+
+    class Pet(BaseModel):
+        grade: Grade | None
+        grp: str
+
+    window = func.window(partition_by="pet.grp", order_by="id")
+    with pytest.warns(SignalSchemaWarning, match="'Grade'"):
+        dc.read_values(id=[1, 2], session=test_session).map(
+            pet=lambda id: Pet(grade=None, grp="g"),
+            output=Pet,
+        ).mutate(
+            composed=func.first("pet.grade").over(window) - 1,
+            labeled=func.first("pet.grade").over(window).label("labeled"),
+        ).save("enum-composed")
+
+        dataset = test_session.catalog.get_dataset("enum-composed", versions=None)
+        schema = dataset.get_version("1.0.0").schema
+        assert schema["composed"].dc_nullable
+        assert schema["labeled"].dc_nullable
+
+        ds = dc.read_dataset("enum-composed", session=test_session).order_by("id")
+        assert ds.to_values("composed") == [None, None]
+        assert ds.to_values("labeled") == [None, None]
+
+
+def test_merge_widens_enum_signal(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Pet(BaseModel):
+        species: Species
+
+    left = dc.read_values(id=[1, 2], session=test_session)
+    right = (
+        dc.read_values(id=[1], session=test_session)
+        .map(pet=lambda id: Pet(species=Species.CAT), output=Pet)
+        .mutate(species=dc.C("pet.species"))
+        .select("id", "species")
+    )
+    merged = left.merge(right, on="id", full=True).order_by("id")
+
+    assert merged.signals_schema.values["species"] == (Species | None)
+    assert merged.to_list("id", "species") == [(1, "cat"), (2, None)]
+
+
+def test_merge_on_enum_signal(test_session):
+    class Species(enum.Enum):
+        CAT = "cat"
+        DOG = "dog"
+
+    class Pet(BaseModel):
+        species: Species
+
+    def enum_chain(ids, kinds):
+        return (
+            dc.read_values(id=ids, kind=kinds, session=test_session)
+            .map(pet=lambda kind: Pet(species=Species(kind)), output=Pet)
+            .mutate(species=dc.C("pet.species"))
+            .select("id", "species")
+        )
+
+    left = enum_chain([1, 2], ["cat", "dog"])
+    right = enum_chain([10], ["dog"])
+    merged = left.merge(right, on="species").order_by("id")
+
+    assert merged.to_list("id", "species", "right_id") == [
+        (1, "cat", None),
+        (2, "dog", 10),
+    ]

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -1,10 +1,10 @@
 import enum
 from collections.abc import Mapping
-from typing import Dict, Literal  # noqa: UP035
+from typing import Annotated, Dict, Literal  # noqa: UP035
 
 import pytest
 
-from datachain.lib.convert.python_to_sql import python_to_sql
+from datachain.lib.convert.python_to_sql import is_nullable_scalar, python_to_sql
 from datachain.sql.types import JSON, Array, Float, Int64, String
 from tests.unit.lib.test_utils import MyModel
 
@@ -92,6 +92,26 @@ def test_enum_value_type_mapping(typ, expected):
 def test_enum_unsupported_value_types(typ):
     with pytest.raises(TypeError, match="enum member values"):
         python_to_sql(typ)
+
+
+@pytest.mark.parametrize(
+    "typ,expected",
+    (
+        (int, True),
+        (str, True),
+        (IntKind, True),
+        (StrMixinKind, True),
+        (Literal["a", "b"], True),
+        (Annotated[int, "meta"], True),
+        (Annotated[list[int], "meta"], False),
+        (MixedKind, False),
+        (list[int], False),
+        (dict[str, int], False),
+        (MyModel, False),
+    ),
+)
+def test_is_nullable_scalar(typ, expected):
+    assert is_nullable_scalar(typ) is expected
 
 
 def test_list_of_tuples_matching_types():


### PR DESCRIPTION
Follow-up to the enum nullability fix: two more sites classified nullable scalars with a bare `NULLABLE_SCALARS` check and so missed enums.

- `Func.is_nullable_result` — `func.first("pet.breed").over(...)` on a `Species | None` field produced a non-nullable physical column, so on ClickHouse a NULL result was stored as the type default (`''`) instead of NULL. Now the result column is `Nullable(String)` and NULL round-trips.
- `SignalSchema.merge`'s scalar widening — an outer/full merge did not widen a top-level enum signal to Optional, so the logical schema claimed a non-optional enum for rows whose value is NULL. Now it widens to `Species | None` like other scalars.

Since these are the fourth and fifth sites needing "nullable scalar, enums included", the classification now lives in one helper, `is_nullable_scalar()`, next to `NULLABLE_SCALARS` — the two inline enum checks from the previous fix use it as well. The remaining direct `NULLABLE_SCALARS` uses are correct as-is: one operates on physical SQL types (where enum columns are already `Int64`/`String`) and the other on arrow dtypes (which cannot be enums).

Both fixes are covered by tests that fail without them: window funcs in the readable-name, column-object, and `.label()` forms, a composed function over a nullable enum (`first(...) - 1`), and merge coverage both on an enum signal and carried through a join. The window tests use all-NULL partitions because ClickHouse's `first_value` skips NULLs by default, so mixed partitions read back differently per backend. Verified on SQLite and ClickHouse.

<sub>🤖 Co-authored by Claude Code and ChatGPT</sub>