### PR TITLE
Add 10-minute timeouts to FFmpeg install steps and cap the studio job at 60

### DIFF
--- a/.github/workflows/tests-studio.yml
+++ b/.github/workflows/tests-studio.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   studio:
     if: '!github.event.pull_request.head.repo.fork'
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -105,6 +106,7 @@ jobs:
         run: make update_datachain_deps "${{ env.BRANCH }}"
 
       - name: Install FFmpeg
+        timeout-minutes: 10
         run: |
           sudo apt update
           sudo apt install -y ffmpeg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,10 +119,12 @@ jobs:
 
       - name: Install FFmpeg on Windows
         if: runner.os == 'Windows'
+        timeout-minutes: 10
         run: choco install ffmpeg --version 7.0.2
 
       - name: Install FFmpeg on macOS
         if: runner.os == 'macOS'
+        timeout-minutes: 10
         # Using ffmpeg@7 since torchcodec does not support ffmpeg 8 yet
         # See: https://github.com/pytorch/torchcodec/issues/839
         # On Windows and Linux ffmpeg < 8 is installed by default
@@ -132,6 +134,7 @@ jobs:
 
       - name: Install FFmpeg on Ubuntu
         if: runner.os == 'Linux'
+        timeout-minutes: 10
         run: |
           sudo apt update
           sudo apt install -y ffmpeg
@@ -212,16 +215,19 @@ jobs:
 
       - name: Install FFmpeg on Windows
         if: runner.os == 'Windows'
+        timeout-minutes: 10
         run: choco install ffmpeg
 
       - name: Install FFmpeg on macOS
         if: runner.os == 'macOS'
+        timeout-minutes: 10
         run: |
           brew install ffmpeg
           echo 'DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib' >> "$GITHUB_ENV"
 
       - name: Install FFmpeg on Ubuntu
         if: runner.os == 'Linux'
+        timeout-minutes: 10
         run: |
           sudo apt update
           sudo apt install -y ffmpeg


### PR DESCRIPTION
Alternative to https://github.com/datachain-ai/datachain/pull/1937

Adds `timeout-minutes: 10` to every FFmpeg install step, and a job-level `timeout-minutes: 60` to the `studio` job, which previously had no cap at all.

## Why

The Azure-internal Ubuntu mirror (`azure.archive.ubuntu.com`) that GitHub's runners use periodically degrades: connections stall or slow to a trickle, and apt waits on them indefinitely because it has no default network timeout. During yesterday's incident, "Install FFmpeg" steps hung for hours across multiple runs on `main` and PR branches (e.g. [this job](https://github.com/datachain-ai/datachain/actions/runs/32166231998/job/95806597098)). This is a known chronic issue with the mirror ([actions/runner-images#7048](https://github.com/actions/runner-images/issues/7048), [#12949](https://github.com/actions/runner-images/issues/12949) — closed by GitHub as won't-fix).

In `Tests`, the job-level timeouts (40/60 min) eventually killed the stuck jobs, but only after eating the whole budget. In `Studio Tests` there was no job timeout, so a stuck job would occupy a runner until GitHub's 6-hour default limit.

Timeouts don't prevent the failure, but they convert a multi-hour silent hang into a fast, visibly red step that can be re-run immediately. The macOS and Windows FFmpeg steps get the same cap since they're the same class of network package install (brew/choco). The normal duration of all these steps is under a minute, so 10 minutes is generous.

<sub>🤖 Co-authored by Claude Code and ChatGPT</sub>