### PR TITLE
Record mutate() expression columns in the dataset version schema

### DIFF
--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -138,6 +138,16 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="DataChain")
 
 
+def _is_coercible_sql_type(sql_type: Any) -> bool:
+    if inspect.isclass(sql_type):
+        return issubclass(sql_type, SQLType)
+    if not isinstance(sql_type, SQLType):
+        return False
+
+    item_type = getattr(sql_type, "item_type", None)
+    return item_type is None or _is_coercible_sql_type(item_type)
+
+
 class DataChainSchema(dict[str, DataType]):
     """Dict-like public view of a DataChain schema.
 
@@ -1675,11 +1685,22 @@ class DataChain:
                     val.type = python_to_sql(type(value))()
                     mutated[name] = val  # type: ignore[assignment]
                 else:
-                    sql_type: Any = python_to_sql(sql_to_python(value))
-                    # nullable physical type so ClickHouse keeps the NULL
-                    if schema._expr_references_nullable(value):
-                        sql_type = SQLType.as_nullable(sql_type)
-                    mutated[name] = sqlalchemy.type_coerce(value, sql_type)  # type: ignore[assignment]
+                    sql_type: Any = value.type
+                    if not isinstance(sql_type, SQLType):
+                        try:
+                            sql_type = python_to_sql(sql_to_python(value))
+                        except TypeError:
+                            sql_type = None
+
+                    # python_to_sql has no mapping for some expression types
+                    # (e.g. enums resolve to a plain python type, dates raise);
+                    # such expressions keep their raw type uncoerced
+                    if _is_coercible_sql_type(sql_type):
+                        # nullable physical type so ClickHouse keeps the NULL
+                        if schema._expr_references_nullable(value):
+                            sql_type = SQLType.as_nullable(sql_type)
+                        value = sqlalchemy.type_coerce(value, sql_type)
+                    mutated[name] = value  # type: ignore[assignment]
 
             new_schema = schema.mutate(kwargs)
         except SignalResolvingError as err:

--- a/src/datachain/lib/dc/datachain.py
+++ b/src/datachain/lib/dc/datachain.py
@@ -1675,13 +1675,11 @@ class DataChain:
                     val.type = python_to_sql(type(value))()
                     mutated[name] = val  # type: ignore[assignment]
                 else:
+                    sql_type: Any = python_to_sql(sql_to_python(value))
                     # nullable physical type so ClickHouse keeps the NULL
                     if schema._expr_references_nullable(value):
-                        sql_type = SQLType.as_nullable(
-                            python_to_sql(sql_to_python(value))
-                        )
-                        value = sqlalchemy.type_coerce(value, sql_type)
-                    mutated[name] = value
+                        sql_type = SQLType.as_nullable(sql_type)
+                    mutated[name] = sqlalchemy.type_coerce(value, sql_type)  # type: ignore[assignment]
 
             new_schema = schema.mutate(kwargs)
         except SignalResolvingError as err:

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -3930,6 +3930,8 @@ def test_mutate_expression_column_through_exports(test_session, tmp_path):
         .order_by("id")
     )
 
+    assert [r["minus"] for r in chain.to_records()] == [0, 1]
+
     df = chain.to_pandas()
     assert df["minus"].tolist() == [0, 1]
 

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -47,7 +47,7 @@ from datachain.lib.signal_schema import (
 from datachain.lib.udf import UDFAdapter
 from datachain.lib.udf_signature import UdfSignatureError
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
-from datachain.sql.types import Float, Int64, SQLType, String
+from datachain.sql.types import Array, Float, Float32, Int64, SQLType, String
 from datachain.utils import STUDIO_URL
 from tests.utils import (
     ANY_VALUE,
@@ -3841,6 +3841,123 @@ def test_mutate_expression_column_through_subtract(test_session):
     assert ds.to_values("minus") == [1, 2]
 
 
+def test_mutate_explicitly_typed_expression_keeps_type(test_session):
+    dc.read_values(a=[1.5, 2.5], session=test_session).mutate(
+        typed_value=sqlalchemy.type_coerce(dc.C("a"), Float32())
+    ).save("mutated-typed")
+
+    dataset = test_session.catalog.get_dataset("mutated-typed", versions=None)
+    assert dataset.get_version("1.0.0").schema["typed_value"] == Float32
+
+    ds = dc.read_dataset("mutated-typed", session=test_session).order_by("a")
+    assert ds.to_values("typed_value") == [1.5, 2.5]
+
+
+def test_mutate_typed_expression_keeps_nullable_array_items(test_session):
+    item_type = SQLType.as_nullable(Float)
+    dc.read_values(
+        vals=[[1.0, None], [2.0, None]],
+        session=test_session,
+        output={"vals": list[float | None]},
+    ).mutate(typed_vals=sqlalchemy.type_coerce(dc.C("vals"), Array(item_type))).save(
+        "mutated-typed-array"
+    )
+
+    dataset = test_session.catalog.get_dataset("mutated-typed-array", versions=None)
+    schema = dataset.get_version("1.0.0").schema
+    assert isinstance(schema["typed_vals"], Array)
+    assert schema["typed_vals"].item_type.dc_nullable
+
+    ds = dc.read_dataset("mutated-typed-array", session=test_session).order_by("vals")
+    values = ds.to_values("typed_vals")
+    assert [v[0] for v in values] == [1.0, 2.0]
+    # None survives as NULL; SQLite reads it back as NaN, ClickHouse as None
+    assert all(v[1] is None or math.isnan(v[1]) for v in values)
+
+
+def test_mutate_expression_column_carried_through_merge(test_session):
+    left = dc.read_values(id=[1, 2], session=test_session).mutate(minus=dc.C("id") - 1)
+    right = dc.read_values(id=[1, 2], tag=["x", "y"], session=test_session)
+    left.merge(right, on="id").save("mutated-carried")
+
+    dataset = test_session.catalog.get_dataset("mutated-carried", versions=None)
+    assert dataset.get_version("1.0.0").schema["minus"] == Int64
+
+    ds = dc.read_dataset("mutated-carried", session=test_session).order_by("id")
+    assert ds.to_list("minus", "tag") == [(0, "x"), (1, "y")]
+
+
+def test_mutate_expression_column_through_slot_window(test_session):
+    window = func.window(partition_by=dc.C("grp"), order_by=dc.C("minus"), desc=True)
+    dc.read_values(id=[1, 2, 3], grp=["a", "a", "b"], session=test_session).mutate(
+        minus=dc.C("id") - 1
+    ).mutate(rank=func.row_number().over(window)).save("mutated-slot-window")
+
+    dataset = test_session.catalog.get_dataset("mutated-slot-window", versions=None)
+    assert dataset.get_version("1.0.0").schema["minus"] == Int64
+
+    ds = dc.read_dataset("mutated-slot-window", session=test_session).order_by("id")
+    assert ds.to_list("minus", "rank") == [(0, 2), (1, 1), (2, 1)]
+
+
+def test_mutate_labeled_expression_column(test_session):
+    dc.read_values(id=[1, 2], session=test_session).mutate(
+        labeled=(dc.C("id") - 1).label("labeled")
+    ).save("mutated-labeled")
+
+    dataset = test_session.catalog.get_dataset("mutated-labeled", versions=None)
+    assert dataset.get_version("1.0.0").schema["labeled"] == Int64
+
+    ds = dc.read_dataset("mutated-labeled", session=test_session).order_by("id")
+    assert ds.to_values("labeled") == [0, 1]
+
+
+def test_mutate_expression_column_as_udf_input(test_session):
+    result = (
+        dc.read_values(id=[1, 2], session=test_session)
+        .mutate(minus=dc.C("id") - 1)
+        .map(doubled=lambda minus: minus * 2, output=int)
+        .order_by("id")
+        .to_values("doubled")
+    )
+    assert result == [0, 2]
+
+
+def test_mutate_expression_column_through_exports(test_session, tmp_path):
+    chain = (
+        dc.read_values(id=[1, 2], session=test_session)
+        .mutate(minus=dc.C("id") - 1)
+        .order_by("id")
+    )
+
+    df = chain.to_pandas()
+    assert df["minus"].tolist() == [0, 1]
+
+    parquet = tmp_path / "out.parquet"
+    chain.to_parquet(parquet)
+    assert dc.read_parquet(parquet, session=test_session).order_by("id").to_values(
+        "minus"
+    ) == [0, 1]
+
+    csv = tmp_path / "out.csv"
+    chain.to_csv(csv)
+    assert dc.read_csv(str(csv), session=test_session).order_by("id").to_values(
+        "minus"
+    ) == [0, 1]
+
+    jsonl = tmp_path / "out.jsonl"
+    chain.to_jsonl(jsonl)
+    assert dc.read_json(str(jsonl), format="jsonl", session=test_session).order_by(
+        "jsonl.id"
+    ).to_values("jsonl.minus") == [0, 1]
+
+    db_url = f"sqlite:///{tmp_path / 'out.db'}"
+    chain.to_database("mutated", db_url)
+    assert dc.read_database(
+        "SELECT id, minus FROM mutated", db_url, session=test_session
+    ).order_by("id").to_values("minus") == [0, 1]
+
+
 def test_mutate_enum_typed_expression_column(test_session):
     # int-valued: clickhouse-sqlalchemy cannot compile string-valued Enum casts
     class Kind(enum.Enum):
@@ -3858,13 +3975,32 @@ def test_mutate_enum_typed_expression_column(test_session):
         ids = ds.to_values("id")
 
     dataset = test_session.catalog.get_dataset("mutated-enum", versions=None)
-    assert dataset.get_version("1.0.0").schema["kind"] == Int64
+    # python_to_sql cannot map an enum to a column type, so the expression is
+    # not coerced and stays out of the flat schema
+    assert "kind" not in dataset.get_version("1.0.0").schema
     assert ids == [1, 2]
 
     # enum definitions are not persisted in feature_schema yet, so the
     # enum-typed signal itself is dropped on reload
     with pytest.raises(SignalResolvingError, match="kind"):
         ds.to_values("kind")
+
+
+def test_mutate_expression_column_with_unmappable_type(test_session):
+    class Kind(enum.Enum):
+        A = 1
+
+    dated = dc.read_values(id=[1, 2], session=test_session).mutate(
+        d=sqlalchemy.cast(sqlalchemy.literal("2024-01-02"), sqlalchemy.Date)
+    )
+    assert len(dated.to_values("d")) == 2
+
+    arrays = dc.read_values(id=[1], session=test_session).mutate(
+        arr=sqlalchemy.cast(
+            sqlalchemy.literal(1), sqlalchemy.ARRAY(sqlalchemy.Enum(Kind))
+        )
+    )
+    assert arrays.signals_schema.values["arr"] == list[Kind]
 
 
 def test_mutate_expression_column_on_empty_chain(test_session):

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -1,4 +1,5 @@
 import datetime
+import enum
 import io
 import json
 import math
@@ -14,6 +15,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+import sqlalchemy
 from pydantic import BaseModel
 
 import datachain as dc
@@ -40,11 +42,12 @@ from datachain.lib.signal_schema import (
     SignalResolvingError,
     SignalResolvingTypeError,
     SignalSchema,
+    SignalSchemaWarning,
 )
 from datachain.lib.udf import UDFAdapter
 from datachain.lib.udf_signature import UdfSignatureError
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
-from datachain.sql.types import Float, Int64, String
+from datachain.sql.types import Float, Int64, SQLType, String
 from datachain.utils import STUDIO_URL
 from tests.utils import (
     ANY_VALUE,
@@ -3671,6 +3674,209 @@ def test_mutate_with_composed_func_expression(test_session):
     )
     # "a" + ".csv" = 5, "hello" + ".csv" = 9, "readme" + ".csv" = 10
     assert result == [5, 9, 10]
+
+
+def test_mutate_expression_column_is_in_saved_schema(test_session):
+    dc.read_values(id=[1, 2], session=test_session).mutate(
+        half=dc.C("id") / 2, minus=dc.C("id") - 1
+    ).save("mutated")
+
+    dataset = test_session.catalog.get_dataset("mutated", versions=None)
+    schema = dataset.get_version("1.0.0").schema
+    assert schema["half"] == Float
+    assert schema["minus"] == Int64
+
+    ds = dc.read_dataset("mutated", session=test_session).order_by("id")
+    assert ds.to_list("half", "minus") == [(0.5, 0), (1.0, 1)]
+
+
+def test_mutate_composed_expression_column_is_in_saved_schema(test_session):
+    dc.read_values(id=[1, 2], session=test_session).mutate(
+        composed=(dc.C("id") - 1) * 2 + dc.C("id") / 2
+    ).save("mutated-composed")
+
+    dataset = test_session.catalog.get_dataset("mutated-composed", versions=None)
+    assert dataset.get_version("1.0.0").schema["composed"] == Float
+
+    ds = dc.read_dataset("mutated-composed", session=test_session).order_by("id")
+    assert ds.to_values("composed") == [0.5, 3.0]
+
+
+def test_mutate_expression_column_only_signal_in_saved_chain(test_session):
+    dc.read_values(id=[1, 2], session=test_session).mutate(minus=dc.C("id") - 1).select(
+        "minus"
+    ).save("mutated-only")
+
+    dataset = test_session.catalog.get_dataset("mutated-only", versions=None)
+    schema = dataset.get_version("1.0.0").schema
+    assert schema["minus"] == Int64
+    assert "id" not in schema
+
+    ds = dc.read_dataset("mutated-only", session=test_session).order_by("minus")
+    assert ds.to_values("minus") == [0, 1]
+
+
+@pytest.mark.parametrize("swap", [False, True])
+def test_mutate_expression_column_through_union(test_session, swap):
+    mutated = dc.read_values(id=[1], session=test_session).mutate(minus=dc.C("id") - 1)
+    plain = dc.read_values(id=[2], minus=[1], session=test_session)
+    first, second = (plain, mutated) if swap else (mutated, plain)
+    first.union(second).save("mutated-union")
+
+    dataset = test_session.catalog.get_dataset("mutated-union", versions=None)
+    assert dataset.get_version("1.0.0").schema["minus"] == Int64
+
+    ds = dc.read_dataset("mutated-union", session=test_session).order_by("id")
+    assert ds.to_list("id", "minus") == [(1, 0), (2, 1)]
+
+
+def test_mutate_renamed_expression_column_is_in_saved_schema(test_session):
+    dc.read_values(id=[1, 2], session=test_session).mutate(minus=dc.C("id") - 1).mutate(
+        renamed=dc.C("minus")
+    ).save("mutated-renamed")
+
+    dataset = test_session.catalog.get_dataset("mutated-renamed", versions=None)
+    schema = dataset.get_version("1.0.0").schema
+    assert schema["renamed"] == Int64
+    assert "minus" not in schema
+
+    ds = dc.read_dataset("mutated-renamed", session=test_session).order_by("id")
+    assert ds.to_values("renamed") == [0, 1]
+
+
+def test_read_dataset_with_expression_column_missing_from_schema(test_session):
+    dc.read_values(id=[1, 2], session=test_session).mutate(minus=dc.C("id") - 1).save(
+        "mutated-legacy"
+    )
+
+    metastore = test_session.catalog.metastore
+    dataset = metastore.get_dataset("mutated-legacy", versions=None)
+    version = dataset.get_version("1.0.0")
+    legacy_schema = {
+        name: typ.to_dict() if isinstance(typ, SQLType) else typ().to_dict()
+        for name, typ in version.schema.items()
+        if name != "minus"
+    }
+    metastore.update_dataset_version(dataset, "1.0.0", schema=legacy_schema)
+
+    ds = dc.read_dataset("mutated-legacy", session=test_session).order_by("id")
+    assert ds.signals_schema.values["minus"] is int
+    assert ds.to_list("id", "minus") == [(1, 0), (2, 1)]
+
+
+def test_mutate_expression_column_composed_with_func(test_session):
+    dc.read_values(name=["ab", "abcd"], session=test_session).mutate(
+        length_plus=string.length("name") + 1
+    ).save("mutated-func-expr")
+
+    dataset = test_session.catalog.get_dataset("mutated-func-expr", versions=None)
+    assert dataset.get_version("1.0.0").schema["length_plus"] == Int64
+
+    ds = dc.read_dataset("mutated-func-expr", session=test_session).order_by("name")
+    assert ds.to_values("length_plus") == [3, 5]
+
+
+def test_mutate_expression_column_through_filter_and_distinct(test_session):
+    dc.read_values(id=[1, 2, 3, 3], session=test_session).mutate(
+        minus=dc.C("id") - 1
+    ).filter(dc.C("minus") > 0).distinct("minus").order_by("minus").save("mutated-ops")
+
+    dataset = test_session.catalog.get_dataset("mutated-ops", versions=None)
+    assert dataset.get_version("1.0.0").schema["minus"] == Int64
+
+    ds = dc.read_dataset("mutated-ops", session=test_session).order_by("minus")
+    assert ds.to_values("minus") == [1, 2]
+
+
+def test_mutate_expression_column_through_group_by(test_session):
+    dc.read_values(id=[1, 2, 3], grp=["a", "a", "b"], session=test_session).mutate(
+        minus=dc.C("id") - 1
+    ).group_by(total=func.sum("minus"), partition_by="grp").save("mutated-group")
+
+    dataset = test_session.catalog.get_dataset("mutated-group", versions=None)
+    assert dataset.get_version("1.0.0").schema["total"] == Int64
+
+    ds = dc.read_dataset("mutated-group", session=test_session).order_by("grp")
+    assert ds.to_list("grp", "total") == [("a", 1), ("b", 2)]
+
+
+def test_mutate_expression_column_through_window(test_session):
+    window = func.window(partition_by="grp", order_by="minus", desc=True)
+    dc.read_values(id=[1, 2, 3], grp=["a", "a", "b"], session=test_session).mutate(
+        minus=dc.C("id") - 1
+    ).mutate(rank=func.row_number().over(window)).save("mutated-window")
+
+    dataset = test_session.catalog.get_dataset("mutated-window", versions=None)
+    schema = dataset.get_version("1.0.0").schema
+    assert schema["minus"] == Int64
+    assert schema["rank"] == Int64
+
+    ds = dc.read_dataset("mutated-window", session=test_session).order_by("id")
+    assert ds.to_list("minus", "rank") == [(0, 2), (1, 1), (2, 1)]
+
+
+def test_mutate_expression_column_through_merge(test_session):
+    left = dc.read_values(id=[1, 2], session=test_session).mutate(minus=dc.C("id") - 1)
+    right = dc.read_values(minus=[0, 1], tag=["x", "y"], session=test_session)
+    left.merge(right, on="minus").save("mutated-merge")
+
+    dataset = test_session.catalog.get_dataset("mutated-merge", versions=None)
+    assert dataset.get_version("1.0.0").schema["minus"] == Int64
+
+    ds = dc.read_dataset("mutated-merge", session=test_session).order_by("id")
+    assert ds.to_list("minus", "tag") == [(0, "x"), (1, "y")]
+
+
+def test_mutate_expression_column_through_subtract(test_session):
+    left = dc.read_values(id=[1, 2, 3], session=test_session).mutate(
+        minus=dc.C("id") - 1
+    )
+    right = dc.read_values(id=[1], session=test_session).mutate(minus=dc.C("id") - 1)
+    left.subtract(right, on="minus").save("mutated-subtract")
+
+    dataset = test_session.catalog.get_dataset("mutated-subtract", versions=None)
+    assert dataset.get_version("1.0.0").schema["minus"] == Int64
+
+    ds = dc.read_dataset("mutated-subtract", session=test_session).order_by("id")
+    assert ds.to_values("minus") == [1, 2]
+
+
+def test_mutate_enum_typed_expression_column(test_session):
+    # int-valued: clickhouse-sqlalchemy cannot compile string-valued Enum casts
+    class Kind(enum.Enum):
+        A = 1
+
+    chain = dc.read_values(id=[1, 2], session=test_session).mutate(
+        kind=sqlalchemy.cast(sqlalchemy.literal(1), sqlalchemy.Enum(Kind))
+    )
+    # rendering is backend-specific (SQLite "1", ClickHouse "A"), type is not
+    assert [type(v) for v in chain.to_values("kind")] == [str, str]
+
+    with pytest.warns(SignalSchemaWarning, match="'Kind'"):
+        chain.save("mutated-enum")
+        ds = dc.read_dataset("mutated-enum", session=test_session).order_by("id")
+        ids = ds.to_values("id")
+
+    dataset = test_session.catalog.get_dataset("mutated-enum", versions=None)
+    assert dataset.get_version("1.0.0").schema["kind"] == Int64
+    assert ids == [1, 2]
+
+    # enum definitions are not persisted in feature_schema yet, so the
+    # enum-typed signal itself is dropped on reload
+    with pytest.raises(SignalResolvingError, match="kind"):
+        ds.to_values("kind")
+
+
+def test_mutate_expression_column_on_empty_chain(test_session):
+    dc.read_values(id=[], session=test_session, output={"id": int}).mutate(
+        minus=dc.C("id") - 1
+    ).save("mutated-empty")
+
+    dataset = test_session.catalog.get_dataset("mutated-empty", versions=None)
+    assert dataset.get_version("1.0.0").schema["minus"] == Int64
+
+    ds = dc.read_dataset("mutated-empty", session=test_session)
+    assert ds.to_values("minus") == []
 
 
 @skip_if_not_sqlite


### PR DESCRIPTION
`mutate()` columns built from plain SQL expressions (e.g. `b=C("a") - 1`) were missing from the persisted `DatasetVersion.schema`. The schema dict is built as `{c.name: c.type.to_dict() for c in columns if isinstance(c.type, SQLType)}`, and expression columns arrived with raw sqlalchemy types (`INTEGER`), so the filter silently dropped them. `feature_schema` and the preview were correct — only the flat schema lost the column, which breaks every consumer that treats it as the column list.

Minimal repro:

```python
import datachain as dc
from datachain import C

dc.read_values(a=[1, 2, 3], name=["x", "y", "z"]).mutate(b=C("a") - 1).save("probe")

ver = catalog.get_dataset("probe", versions=None).get_version("1.0.0")
```

Before:

```python
ver.schema          # {'sys__id': UInt64, 'sys__rand': UInt64, 'a': Int64, 'name': String}  — no 'b'
ver.feature_schema  # {'a': 'int', 'name': 'str', 'b': 'int'}  — correct
```

After: `ver.schema` includes `'b': Int64`.

The fix is in the mutate expression branch: `type_coerce` the expression to its datachain SQLType (`python_to_sql(sql_to_python(...))`), the same coercion the nullable path already did. Func/window, group_by, and literal columns already carried SQLTypes, so this was the only save path producing raw types. As a side effect the physical column type is now the canonical one (ClickHouse: `Int64` instead of `Int32`; `Nullable(Int64)` preserved for nullable expressions).

Not every expression type is coercible on main: `python_to_sql` returns a plain python type for enums, raises for `Date`/`Time`, and produces an `Array` with an invalid item type for `ARRAY(Enum(...))`. Coercion is therefore guarded — an expression whose type cannot be resolved to a valid `SQLType` keeps its raw type and stays out of the flat schema, exactly as on main today. Pinned by tests: an enum-cast column (reads work pre-save, save warns, column absent from `.schema`, signal dropped on reload), a `Date` cast, and an `ARRAY(Enum)` cast.

<sub>🤖 Co-authored by Claude Code and ChatGPT</sub>
