### PR TITLE
fix: refuse a dict whose keys collide as JSON instead of losing a value

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -1,5 +1,6 @@
 import glob
 import itertools
+import json as stdlib_json
 import logging
 import posixpath
 import secrets
@@ -57,6 +58,22 @@ logger = logging.getLogger("datachain")
 SELECT_BATCH_SIZE = 100_000  # number of rows to fetch at a time
 
 
+class _KeyCollisionError(ValueError):
+    """Two keys of one mapping would be written as the same JSON name."""
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise _KeyCollisionError(
+                f"Two keys serialize to the JSON key {key!r}, so one of their "
+                "values would be lost."
+            )
+        seen[key] = value
+    return seen
+
+
 class AbstractWarehouse(ABC, Serializable):
     """
     Abstract Warehouse class, to be implemented by any Database Adapters
@@ -105,6 +122,7 @@ class AbstractWarehouse(ABC, Serializable):
 
         if isinstance(obj, dict):
             out: dict[str, Any] = {}
+            seen: dict[str, Any] = {}
             for k, v in obj.items():
                 if not isinstance(k, str):
                     key_str = json.dumps(
@@ -113,7 +131,17 @@ class AbstractWarehouse(ABC, Serializable):
                         serialize_numpy=True,
                     )
                 else:
-                    key_str = k
+                    # str.__str__: collapses a str subclass whose __eq__ would
+                    # hide a duplicate, without invoking an overridden __str__
+                    # that would disagree with the key json actually emits.
+                    key_str = str.__str__(k)
+                if key_str in out:
+                    raise _KeyCollisionError(
+                        f"Keys {seen[key_str]!r} and {k!r} both serialize to the "
+                        f"JSON key {key_str!r}, so one of their values would be "
+                        "lost."
+                    )
+                seen[key_str] = k
                 out[key_str] = self._to_jsonable(v)
             return out
 
@@ -121,6 +149,44 @@ class AbstractWarehouse(ABC, Serializable):
             return [self._to_jsonable(i) for i in obj]
 
         return obj
+
+    def _dump_json(self, obj: Any, col_name: str) -> str:
+        """Serialize and check the result for duplicate property names.
+
+        JSON columns store this text. Array items are stored as they are and
+        serialized later by sqlite3's registered adapter; this is a separate
+        preflight serialization that predicts what the adapter will write, and
+        only matches while both call datachain.json.dumps with these options.
+
+        The encoder chooses the key spelling, and serialize_numpy materializes
+        mappings out of object arrays, so a duplicate property is only visible in
+        the emitted text.
+        """
+        try:
+            dumped = json.dumps(obj, ensure_ascii=False, serialize_numpy=True)
+        except TypeError as e:
+            # This is the encoder that stores the value, so refusing here only
+            # refuses what could not have been stored.
+            raise JsonSerializationError(
+                f"JSON serialization error: {e}",
+                column_name=col_name,
+                value_repr=repr(obj),
+            ) from e
+        try:
+            stdlib_json.loads(dumped, object_pairs_hook=_reject_duplicate_keys)
+        except _KeyCollisionError as e:
+            raise JsonSerializationError(
+                str(e), column_name=col_name, value_repr=repr(obj)
+            ) from e
+        return dumped
+
+    def _jsonable_or_raise(self, val: Any, col_name: str) -> Any:
+        try:
+            return self._to_jsonable(val)
+        except _KeyCollisionError as e:
+            raise JsonSerializationError(
+                str(e), column_name=col_name, value_repr=repr(val)
+            ) from e
 
     def convert_type(  # noqa: PLR0911
         self,
@@ -152,6 +218,8 @@ class AbstractWarehouse(ABC, Serializable):
 
             if item_python_type is not list:
                 if isinstance(val[0], item_python_type):
+                    if item_python_type is dict:
+                        self._dump_json(val, col_name)
                     # SQLite ARRAY storage expects a list; tuples/sets must be
                     # converted to lists even when element types already match.
                     return list(val)
@@ -172,15 +240,7 @@ class AbstractWarehouse(ABC, Serializable):
         if col_python_type is dict or col_type_name == "JSON":
             if value_type is str:
                 return val
-            json_ready = self._to_jsonable(val)
-            try:
-                return json.dumps(json_ready, ensure_ascii=False, serialize_numpy=True)
-            except TypeError as e:
-                raise JsonSerializationError(
-                    f"JSON serialization error: {e}",
-                    column_name=col_name,
-                    value_repr=repr(val),
-                ) from e
+            return self._dump_json(self._jsonable_or_raise(val, col_name), col_name)
 
         if isinstance(val, col_python_type):
             return val

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 import datachain as dc
 import datachain.query.dataset as query_dataset
 from datachain import Column, func
+from datachain.data_storage.warehouse import AbstractWarehouse
 from datachain.dataset import DatasetStatus
 from datachain.error import (
     DatasetInvalidVersionError,
@@ -45,7 +46,7 @@ from datachain.lib.signal_schema import (
     SignalSchema,
     SignalSchemaWarning,
 )
-from datachain.lib.udf import BindContext, BoundSpec, UDFAdapter
+from datachain.lib.udf import BindContext, BoundSpec, UDFAdapter, UdfError
 from datachain.lib.udf_signature import UdfSignatureError
 from datachain.lib.utils import DataChainColumnError, DataChainParamsError
 from datachain.sql.types import Array, Float, Float32, Int64, SQLType, String
@@ -964,6 +965,149 @@ def test_map_hydrates_models_in_variadic_tuple_param(test_session):
     ).map(count=total, params=["collection.items"])
 
     assert chain.to_values("count") == [9]
+
+
+@pytest.mark.parametrize("shape", ["bare", "in-a-list"])
+def test_save_refuses_colliding_dict_keys_inside_a_model(test_session, shape):
+    class Inner(DataModel):
+        lookup: dict[str | int, str]
+
+    inner = Inner(lookup=dict(_CLASHING))
+    annotation, value = {
+        "bare": (Inner, inner),
+        "in-a-list": (list[Inner], [inner]),
+    }[shape]
+    holder = type("Holder", (DataModel,), {"__annotations__": {"rows": annotation}})
+
+    chain = dc.read_values(collection=[holder(rows=value)], session=test_session)
+
+    with pytest.raises(UdfError, match="would be lost"):
+        chain.save("model_keys")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="these shapes reach the converter as live model instances, and pydantic "
+    "merges colliding keys inside model_dump(mode='json') before anything here can "
+    "see them. model_dump_json keeps both, but reading it means serializing twice, "
+    "which re-runs field serializers -- draining a one-shot iterator and letting a "
+    "stateful one write different keys than were checked. Needs a single-pass hook "
+    "pydantic does not offer. Tracked on #1914.",
+)
+@pytest.mark.parametrize("shape", ["in-a-tuple", "in-a-dict-of-lists"])
+def test_save_refuses_colliding_dict_keys_inside_a_live_model(test_session, shape):
+    class Inner(DataModel):
+        lookup: dict[str | int, str]
+
+    inner = Inner(lookup=dict(_CLASHING))
+    annotation, value = {
+        "in-a-tuple": (tuple[Inner, ...], (inner,)),
+        "in-a-dict-of-lists": (dict[str, list[Inner]], {"k": [inner]}),
+    }[shape]
+    holder = type("Holder", (DataModel,), {"__annotations__": {"rows": annotation}})
+
+    chain = dc.read_values(collection=[holder(rows=value)], session=test_session)
+
+    with pytest.raises(UdfError, match="would be lost"):
+        chain.save("live_model_keys")
+
+
+@pytest.mark.parametrize(
+    "value", [float("nan"), float("inf"), float("-inf")], ids=["nan", "inf", "-inf"]
+)
+def test_save_keeps_a_model_float_json_cannot_spell(test_session, value):
+    class Measure(DataModel):
+        v: float
+
+    saved = dc.read_values(m=[Measure(v=value)], session=test_session).save("finite")
+
+    assert repr(saved.to_values("m.v")[0]) == repr(value)
+
+
+def test_save_writes_no_rows_when_a_later_row_has_colliding_keys(
+    test_session, monkeypatch
+):
+    monkeypatch.setattr(AbstractWarehouse, "INSERT_BATCH_SIZE", 4)
+
+    class Holder(DataModel):
+        rows: list[dict]
+
+    values = [Holder(rows=[{"a": i}]) for i in range(12)]
+    values[9] = Holder(rows=[dict(_CLASHING)])
+
+    chain = dc.read_values(collection=values, session=test_session)
+
+    with pytest.raises(UdfError, match="would be lost"):
+        chain.save("late_collision")
+
+    # read_dataset would fall back to Studio for a missing name
+    with pytest.raises(DatasetNotFoundError):
+        test_session.catalog.get_dataset("late_collision")
+
+
+@skip_if_not_sqlite
+def test_filter_matches_a_saved_list_of_dicts(test_session):
+    class Holder(dc.DataModel):
+        rows: list[dict[str, int]]
+
+    saved = dc.read_values(x=[Holder(rows=[{"a": 1}])], session=test_session).save(
+        "dict_rows"
+    )
+
+    assert saved.filter(C("x.rows") == [{"a": 1}]).count() == 1
+
+
+_CLASHING = {"1": "first", 1: "second"}
+
+
+def test_save_refuses_a_dict_whose_keys_collide_as_json(test_session):
+    class Ambiguous(DataModel):
+        lookup: dict[str | int, str]
+
+    chain = dc.read_values(
+        collection=[Ambiguous(lookup={"1": "first", 1: "second"})],
+        session=test_session,
+    )
+
+    # both keys become the JSON key "1", so one value would vanish with nothing
+    # on the read side able to recover it
+    with pytest.raises(UdfError, match="would be lost"):
+        chain.save("ambiguous_keys")
+
+
+def test_save_keeps_both_entries_when_dict_keys_do_not_collide(test_session):
+    class Ambiguous(DataModel):
+        lookup: dict[str | int, str]
+
+    saved = dc.read_values(
+        collection=[Ambiguous(lookup={"x": "a", 2: "b"})], session=test_session
+    ).save("no_clash")
+
+    # both entries survive, but the declared int key reads back as a JSON string
+    (out,) = saved.to_values("collection.lookup")
+    assert out == {"x": "a", "2": "b"}
+    assert [type(k) for k in out] == [str, str]
+
+
+@pytest.mark.parametrize(
+    "annotation,value",
+    [
+        (list[dict[str | int, str]], [_CLASHING]),
+        (list[list[dict[str | int, str]]], [[_CLASHING]]),
+        (tuple[dict[str | int, str], ...], (_CLASHING,)),
+        (dict[str, dict[str | int, str]], {"k": _CLASHING}),
+    ],
+    ids=["in-a-list", "in-a-nested-list", "in-a-tuple", "in-a-dict"],
+)
+def test_save_refuses_colliding_dict_keys_inside_a_collection(
+    test_session, annotation, value
+):
+    holder = type("Holder", (DataModel,), {"__annotations__": {"rows": annotation}})
+
+    chain = dc.read_values(collection=[holder(rows=value)], session=test_session)
+
+    with pytest.raises(UdfError, match="would be lost"):
+        chain.save("nested_keys")
 
 
 def test_map_preserves_json_looking_key_for_optional_str_key(test_session):

--- a/tests/unit/test_warehouse.py
+++ b/tests/unit/test_warehouse.py
@@ -1,7 +1,10 @@
 import base64
+import datetime
 import json
+from enum import Enum
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 import sqlalchemy as sa
 
@@ -9,6 +12,9 @@ import datachain as dc
 from datachain.data_storage.serializer import deserialize
 from datachain.data_storage.sqlite import SQLiteWarehouse
 from datachain.lib.file import File
+from datachain.lib.udf import JsonSerializationError
+from datachain.sql.types import JSON, Array, Float, String
+from tests.utils import skip_if_not_sqlite
 
 
 def test_serialize(sqlite_db):
@@ -225,3 +231,182 @@ def test_select_node_fields_by_parent_path_tar_wildcards_are_literal(
         "dir_%1/b.csv",
         "dir_%1/nested/c.csv",
     ]
+
+
+class _StrEnum(str, Enum):
+    A = "a"
+    B = "b"
+    ONE = "1"
+
+
+class _Mangled(str):
+    """A str subclass whose __str__ disagrees with the key json emits."""
+
+    __slots__ = ()
+
+    def __str__(self):
+        return "MANGLED"
+
+
+class _OpaqueStr(str):
+    """A str subclass whose equality cannot spot a duplicate key."""
+
+    __slots__ = ()
+    __eq__ = object.__eq__
+    __hash__ = object.__hash__
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"1": "a", 1: "b"},
+        {None: "a", "null": "b"},
+        {True: "a", "true": "b"},
+        {(1, 2): "a", "[1,2]": "b"},
+        {"1": "a", _OpaqueStr("1"): "b"},
+        {_StrEnum.ONE: "a", 1: "b"},
+    ],
+    ids=[
+        "int-and-str",
+        "none-and-null",
+        "bool-and-str",
+        "tuple-and-str",
+        "subclass",
+        "enum-value-and-int",
+    ],
+)
+def test_convert_type_refuses_colliding_dict_keys(warehouse, value):
+    with pytest.raises(JsonSerializationError, match="would be lost"):
+        warehouse.convert_type(value, JSON(), dict, "JSON", "c")
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ({"x": "a", 2: "b"}, {"x": "a", "2": "b"}),
+        ({1: "a", 2: "b"}, {"1": "a", "2": "b"}),
+        ({_StrEnum.A: "x", _StrEnum.B: "y"}, {"a": "x", "b": "y"}),
+        ({_StrEnum.A: "x", "_StrEnum.A": "y"}, {"a": "x", "_StrEnum.A": "y"}),
+        ({_Mangled("a"): "x"}, {"a": "x"}),
+    ],
+    ids=["mixed", "all-int", "enum", "enum-and-its-label", "custom-str"],
+)
+def test_convert_type_keeps_dict_keys_that_do_not_collide(warehouse, value, expected):
+    got = warehouse.convert_type(value, JSON(), dict, "JSON", "c")
+    assert json.loads(got) == expected
+
+
+@pytest.mark.parametrize(
+    "value,col_type,expected",
+    [
+        ([1, 2], Array(Float()), [1.0, 2.0]),
+        (("x", "y"), Array(String()), ["x", "y"]),
+    ],
+    ids=["float-from-int", "tuple-to-list"],
+)
+def test_convert_type_converts_array_items(warehouse, value, col_type, expected):
+    assert warehouse.convert_type(value, col_type, list, "Array", "c") == expected
+
+
+@skip_if_not_sqlite
+def test_convert_type_keeps_a_numpy_object_array_that_adds_keys(warehouse):
+    value = [{"payload": np.array([{"a": 1}], dtype=object)}]
+
+    assert warehouse.convert_type(value, Array(JSON()), list, "Array", "c") == value
+
+
+@pytest.mark.parametrize(
+    "value,col_type,col_python_type,col_type_name",
+    [
+        (
+            [
+                {
+                    "1": "first",
+                    1: "second",
+                    "payload": np.array([{"a": 1}], dtype=object),
+                }
+            ],
+            Array(JSON()),
+            list,
+            "Array",
+        ),
+        (
+            {"payload": np.array([{"1": "first", 1: "second"}], dtype=object)},
+            JSON(),
+            dict,
+            "JSON",
+        ),
+    ],
+    ids=["array-item", "top-level"],
+)
+def test_convert_type_refuses_a_collision_a_numpy_array_hides(
+    warehouse, value, col_type, col_python_type, col_type_name
+):
+    with pytest.raises(JsonSerializationError, match="would be lost"):
+        warehouse.convert_type(value, col_type, col_python_type, col_type_name, "m__d")
+
+
+@skip_if_not_sqlite
+def test_convert_type_names_the_column_for_an_unserializable_array_item(warehouse):
+    with pytest.raises(JsonSerializationError) as excinfo:
+        warehouse.convert_type([{"k": {1, 2}}], Array(JSON()), list, "Array", "m__d")
+
+    assert excinfo.value.column_name == "m__d"
+
+
+@skip_if_not_sqlite
+def test_convert_type_keeps_array_dict_keys_the_driver_stores_apart(warehouse):
+    value = [{(1, 2): "tuple", "[1,2]": "string"}]
+
+    assert warehouse.convert_type(value, Array(JSON()), list, "Array", "c") == value
+
+
+@skip_if_not_sqlite
+@pytest.mark.parametrize(
+    "value",
+    [
+        [{(1, 2): "tuple", "(1, 2)": "string"}],
+        [{datetime.date(2020, 1, 2): "date", "2020-01-02": "string"}],
+    ],
+    ids=["tuple-key", "date-key"],
+)
+def test_convert_type_refuses_array_dict_keys_the_driver_merges(warehouse, value):
+    with pytest.raises(JsonSerializationError, match="would be lost"):
+        warehouse.convert_type(value, Array(JSON()), list, "Array", "c")
+
+
+def test_convert_type_does_not_re_encode_dict_array_items(warehouse):
+    value = [{"a": 1}, {"b": 2}]
+
+    got = warehouse.convert_type(value, Array(JSON()), list, "Array", "c")
+
+    if warehouse.python_type(JSON()) is dict:
+        assert got == value
+    else:
+        assert got == ['{"a":1}', '{"b":2}']
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="_numpy_to_python rebuilds the mapping while materializing an object "
+    "array, so np.datetime64('NaT', 'ns') and None collapse onto one None key "
+    "there, "
+    "before any emitted JSON exists to read. Pre-existing; tracked on #1914.",
+)
+def test_convert_type_refuses_a_collision_numpy_normalization_hides(warehouse):
+    value = {
+        "payload": np.array(
+            [{np.datetime64("NaT", "ns"): "a", None: "b"}], dtype=object
+        )
+    }
+
+    with pytest.raises(JsonSerializationError, match="would be lost"):
+        warehouse.convert_type(value, JSON(), dict, "JSON", "c")
+
+
+def test_convert_type_names_the_column_for_a_colliding_dict(warehouse):
+    with pytest.raises(JsonSerializationError) as excinfo:
+        warehouse.convert_type({"1": "a", 1: "b"}, JSON(), dict, "JSON", "m__d")
+
+    assert excinfo.value.column_name == "m__d"
+    assert "both serialize to the JSON key '1'" in str(excinfo.value)


### PR DESCRIPTION
Refs #1914 — two shapes are left, both pinned by strict `xfail`; see *Known gaps*.

> [!WARNING]
> **Draft — not ready to merge.** The write-time check works, but it leans on
> markers and backend-specific assertions that should not land as they are.

## TODO before this is mergeable

Three xfails and five SQLite-only tests. Each is a real gap, not a formality:

- [ ] **Two xfails: a live Pydantic model still loses colliding keys.**
      `tuple[Model, ...]` and `dict[str, list[Model]]` reach the converter as
      model instances, and `model_dump(mode="json")` merges the keys inside
      Pydantic before anything here can look. Closing this needs models converted
      in Pydantic's *python* mode everywhere, which preserves both keys — and that
      needs this project's encoder to first cover the types only JSON mode knows
      (`timedelta`, paths, addresses, plain enums, sets), or those regress.
- [ ] **One xfail: a numpy object array collapses keys before any JSON exists.**
      `_numpy_to_python` rebuilds the mapping while materializing the array, so
      `np.datetime64("NaT", "ns")` and `None` land on one key. This is our own
      code and the fix belongs where the merge happens.
- [ ] **Five `skip_if_not_sqlite` tests.** They assert what SQLite's adapter
      writes, which has no ClickHouse equivalent — there a JSON item resolves to
      `str`, so dict items never take that path. They should assert a relationship
      that holds on both backends rather than a physical form. The pattern works:
      one test already compares two shapes' stored values instead of naming either.

Until those are addressed this documents a defect rather than fixing it, and the
markers would become permanent furniture in the test suite.

## The problem

JSON names are strings, so distinct Python keys can collapse onto one when a `dict` is serialized. `1` and `"1"` both become `"1"`, the last one wins, and the row is written with a value missing — silently, with nothing on the read side able to recover it.

```python
class M(dc.DataModel):
    d: dict[str | int, str]

dc.read_values(m=[M(d={"1": "foo", 1: "bar"})]).save("m")
# read back: {"1": "bar"}   <- "foo" is gone
```

## The shape of the fix

Every earlier revision of this PR failed the same way: it tried to *predict* what a serializer would write. Each prediction drifted from the real thing in both directions — refusing valid data and missing real losses. What works is reading what the writer actually produced.

**`_to_jsonable` checks as it builds.** It constructs the dict itself, JSON-encoding non-`str` keys so `key_needs_json_decode` can read them back. A collision there merges the values before anything is serialized, so there is no later output to inspect.

**Everything stored unconverted is checked from the emitted JSON.** Those values are spelled by the driver's own encoder — `sqlite3`'s registered `adapt_array`, which is `datachain.json.dumps`. It spells a tuple key `(1, 2)` where `_to_jsonable` spells it `[1,2]`, and with `serialize_numpy` it materializes object arrays into mappings the input never contained. Neither is predictable, so the emitted JSON is parsed with a duplicate-preserving `object_pairs_hook`.

`convert_type` calls that before storing an array of dicts. Without it the guard would not fire until `sqlite3` adapted the value mid-insert, with no column to name:

```
UdfError: UDF returned an invalid value for output column 'm__d'. Expected
JSON-serializable dict[Union[str, int], str]. Keys '1' and 1 both serialize
to the JSON key '1', so one of their values would be lost.
```

Verified that a poisoned row in the middle of a 2000-row save leaves nothing written.

**80 source lines** in one file: an exception, a hook, and one `_dump_json` shared by both branches.

## Known gaps

Both are pre-existing, both stay on #1914, and both are pinned by strict `xfail` so they convert to failures when fixed.

**A live pydantic instance.** `model_dump(mode="json")` merges colliding keys inside pydantic-core, before anything here can see them. This is reachable for `tuple[Model, ...]` and `dict[str, list[Model]]`, where the value arrives as a model rather than flattened. (`read_values` flattens `Model` and `list[Model]` to plain dicts first, so those *are* caught, by `_to_jsonable`'s own check.)

I attempted this and reverted it. `model_dump_json()` keeps both keys and emits a duplicate property, so reading that JSON detects the collision — but it is a second serialization pass, and that re-runs field serializers:

```python
@field_serializer("items")
def materialize(self, value):
    return list(value)

# given iter([1, 2, 3]) --  main: 1 call, stores [1, 2, 3]
#                          that revision: 2 calls, stores []
```

A stateful serializer could likewise emit safe keys during the check and colliding ones during storage. `model_dump_json` also writes `nan` and the infinities as `null`, which `model_dump` preserves. Closing this needs a single-pass hook pydantic does not offer, so it is deferred rather than approximated.

**A numpy object array.** `_numpy_to_python` rebuilds a mapping while materializing the array, so `np.datetime64("NaT", "ns")` and `None` collapse onto one `None` key *there*, before any emitted JSON exists to read. Other numpy-created mappings are covered, since the encoder builds them where the emitted JSON can be read.

## Why detect the collision rather than reject the annotation

The issue suggested refusing ambiguous key annotations at schema-build time. Detecting the actual collision is better on three counts:

- **No false positives.** `dict[str | int, str]` holding `{"x": "a", 2: "b"}` keeps working. Rejecting the annotation would break it.
- **It catches shapes an annotation rule would miss** — a `str` subclass whose `__eq__` hides a duplicate has a perfectly ordinary annotation.
- **It fires where the data is lost**, so the message names the actual keys.

For the record: `is_chain_type` already refuses `dict[str | int, X]`. The loss was reachable because **model fields never consult it** — the gap tracked in #1942.

## Cost

Not measurable where it matters. A saved row costs ~240 µs and these differences are single-digit µs; across repeated end-to-end runs `main` and this branch are indistinguishable. In isolation, `convert_type` on a 20-element `list[dict]` goes 0.74 → 7.7 µs. Element types other than `dict` are untouched.

## Validation

Rebased onto `bc3e2c83`. `tests/unit`: 3178 passed, 15 skipped, 18 xfailed. `tests/func/test_datachain.py` + `test_udf.py` + `test_datasets.py`: 449 passed, 117 skipped — one flake in `test_udf_parallel_worker_failure_exits_peers`, which passes on rerun and fails the same way on `main`. ruff 0.16.4 and mypy 2.3.0 clean, matching the pins in `.pre-commit-config.yaml`.

Tests go through `convert_type` or the chain API. Coverage includes the collision (int/str, `None`/`"null"`, `bool`/`"true"`, tuple/str, `str` subclass, `str`-mixin enum), the four nested-collection shapes, the encoder's key spelling in both directions, the numpy-created mapping that *is* caught, the flattened model shapes, and a round trip of `nan`/`inf`/`-inf` through `save`.

Five tests carry `skip_if_not_sqlite`: they assert what `sqlite3`'s adapter stores, which has no ClickHouse equivalent — there a JSON item resolves to `str`, so dict items never take that path. The one test that derives its expectation from `warehouse.python_type(JSON())` runs on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

