### PR TITLE
feat(studio): show the compute cluster in `datachain job ls --extended`

### DIFF
--- a/docs/commands/job/ls.md
+++ b/docs/commands/job/ls.md
@@ -5,7 +5,7 @@ List jobs in Studio.
 ## Synopsis
 
 ```usage
-usage: datachain job ls [-h] [-v] [-q] [--status STATUS] [--team TEAM] [--limit LIMIT]
+usage: datachain job ls [-h] [-v] [-q] [--status STATUS] [--team TEAM] [--limit LIMIT] [-e]
 ```
 
 ## Description
@@ -18,6 +18,7 @@ This command lists jobs in Studio. You can filter jobs by their status, specify 
 * `--status STATUS` - Status to filter jobs by
 * `--team TEAM` - Team to list jobs for (default: from config)
 * `--limit LIMIT` - Limit the number of jobs returned (default: 20)
+* `-e`, `--extended` - Show extra job details, such as the compute cluster
 * `-h`, `--help` - Show the help message and exit
 * `-v`, `--verbose` - Be verbose
 * `-q`, `--quiet` - Be quiet
@@ -75,6 +76,11 @@ datachain job ls --limit 50
 5. List jobs with verbose output:
 ```bash
 datachain job ls -v
+```
+
+6. List jobs with extra details, including the compute cluster they ran on:
+```bash
+datachain job ls --extended
 ```
 
 ## Notes

--- a/src/datachain/cli/parser/job.py
+++ b/src/datachain/cli/parser/job.py
@@ -162,6 +162,13 @@ def add_jobs_parser(subparsers, parent_parser) -> None:
         default=20,
         help="Limit the number of jobs returned (default: 20)",
     )
+    studio_ls_parser.add_argument(
+        "-e",
+        "--extended",
+        action="store_true",
+        default=False,
+        help="Show extra job details, such as the compute cluster",
+    )
 
     studio_cancel_help = "Cancel a job in Studio"
     studio_cancel_description = "Cancel a running job in Studio."

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -73,7 +73,7 @@ def process_jobs_args(args: "Namespace"):
         return show_job_logs(args.id, args.team)
 
     if args.cmd == "ls":
-        return list_jobs(args.status, args.team, args.limit)
+        return list_jobs(args.status, args.team, args.limit, args.extended)
 
     if args.cmd == "clusters":
         return list_clusters(args.team)
@@ -714,7 +714,9 @@ def cancel_job(job_id: str, team_name: str | None):
     print(f"Job {job_id} canceled")
 
 
-def list_jobs(status: str | None, team_name: str | None, limit: int):
+def list_jobs(
+    status: str | None, team_name: str | None, limit: int, extended: bool = False
+):
     client = StudioClient(team=team_name)
     response = client.get_jobs(status, limit)
     if not response.ok:
@@ -725,16 +727,18 @@ def list_jobs(status: str | None, team_name: str | None, limit: int):
         print("No jobs found")
         return
 
-    rows = [
-        {
+    rows = []
+    for job in jobs:
+        row = {
             "ID": job.get("id"),
             "Name": job.get("name"),
             "Status": job.get("status"),
             "Created at": job.get("created_at"),
             "Created by": job.get("created_by"),
         }
-        for job in jobs
-    ]
+        if extended:
+            row["Cluster"] = job.get("compute_cluster_name")
+        rows.append(row)
 
     print(tabulate.tabulate(rows, headers="keys", tablefmt="grid"))
 

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -681,6 +681,46 @@ def test_studio_rm_dataset(capsys, mocker):
         }
 
 
+def test_studio_list_jobs(capsys):
+    with Config(ConfigLevel.GLOBAL).edit() as conf:
+        conf["studio"] = {"token": "isat_access_token", "team": "team_name"}
+
+    with requests_mock.mock() as m:
+        m.get(
+            re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
+            json=[
+                {
+                    "id": "8bddde6c-c3ca-41b0-9d87-ee945bfdce70",
+                    "name": "on-cluster",
+                    "status": "COMPLETE",
+                    "compute_cluster_id": 1,
+                    "compute_cluster_name": "prod-cluster",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "created_by": "user",
+                },
+                {
+                    "id": "0502eef6-a32e-45fa-8e3b-d20ec0abbcf0",
+                    "name": "on-other-cluster",
+                    "status": "FAILED",
+                    "compute_cluster_id": 2,
+                    "compute_cluster_name": "dev-cluster",
+                    "created_at": "2021-01-02T00:00:00Z",
+                    "created_by": "user",
+                },
+            ],
+        )
+
+        assert main(["job", "ls"]) == 0
+        out = capsys.readouterr().out
+        assert "Cluster" not in out
+        assert "prod-cluster" not in out
+
+        assert main(["job", "ls", "--extended"]) == 0
+        out = capsys.readouterr().out
+        assert "Cluster" in out
+        assert "prod-cluster" in out
+
+
 def test_studio_cancel_job(capsys, mocker):
     job_id = "8bddde6c-c3ca-41b0-9d87-ee945bfdce70"
     with requests_mock.mock() as m:


### PR DESCRIPTION
Studio's job API now returns the compute cluster on each job
(`compute_cluster_id`, `compute_cluster_name` — datachain-ai/studio#13178), so
the cluster a job ran on can be shown instead of dropped.

The default `datachain job ls` output stays as it is — ID / Name / Status /
Created at / Created by — and the cluster is opt-in behind a new `-e` /
`--extended` flag, which is the place for further job detail we don't want in
the default table. `--extended` appends a `Cluster` column with the cluster
name.

No `StudioClient` change is needed — `JobData` is `dict[str, Any]`, so the new
fields already arrive. The jobs skill (`datachain/skill/jobs/scripts/jobs.py`)
already resolves `compute_cluster_name` and starts populating cluster names on
its own.

Added `test_studio_list_jobs`, which mocks the jobs endpoint and asserts the
column is absent by default and present with `--extended`. Docs for the command
list the new flag. `pytest tests/test_cli_studio.py` — 56 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
