### PR TITLE
feat(llm): add OrcaRouter as a named LLM provider

### DIFF
--- a/docs/references/llm.md
+++ b/docs/references/llm.md
@@ -94,6 +94,21 @@ explicitly with `.settings(llm_params=...)`. A dict of params is part of the cac
 key; a callable (resolved per worker, e.g. for secrets) is not, so put
 output-affecting params in the dict form or in per-call keyword arguments.
 
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway; a model
+string of `orcarouter/<model>` routes to `https://api.orcarouter.ai/v1` with the
+`ORCAROUTER_API_KEY` credential (or an `api_key` passed via `llm_params`). Its
+`orcarouter/auto` alias picks a default model for you:
+
+```python
+.settings(llm="orcarouter/auto", llm_params={"api_key": os.environ["ORCAROUTER_API_KEY"]})
+```
+
+The gateway also runs gateway-level, zero-trust security for AI agents on the same
+endpoint — screening every prompt/response and governing every tool call on a
+default-deny basis, with no application code changes.
+
 ## Token usage
 
 Pass `include_usage=True` to capture token counts for a call. The function then

--- a/src/datachain/llm/engine.py
+++ b/src/datachain/llm/engine.py
@@ -1,4 +1,5 @@
 from functools import cache
+from os import environ
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError, create_model
@@ -21,6 +22,9 @@ RESERVED_PARAMS = frozenset(
     {"model", "messages", "input", "num_retries", "fallbacks", "response_format"}
 )
 
+ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1"
+ORCAROUTER_API_KEY_ENV = "ORCAROUTER_API_KEY"
+
 
 def _litellm():
     # Imported lazily (it is slow to import) so `import datachain` stays fast.
@@ -35,6 +39,28 @@ def _fallbacks(fallback: str | list[str] | None) -> list[str] | None:
     return [fallback] if isinstance(fallback, str) else list(fallback)
 
 
+def _orcarouter_kwargs(params: dict[str, Any]) -> dict[str, Any]:
+    """Wire a `orcarouter/<model>` string to the OrcaRouter gateway.
+
+    OrcaRouter is an OpenAI-compatible router, so the call is routed as a plain
+    OpenAI chat/embedding request against `https://api.orcarouter.ai/v1`. An
+    `ORCAROUTER_API_KEY` must be set (or passed via `llm_params`); an explicit key
+    is required so an unrelated `OPENAI_API_KEY` is never sent to the gateway.
+    """
+    kwargs: dict[str, Any] = {
+        "api_base": ORCAROUTER_API_BASE,
+        "custom_llm_provider": "openai",
+    }
+    key = params.get("api_key") or environ.get(ORCAROUTER_API_KEY_ENV)
+    if not key:
+        raise LLMError(
+            f"model 'orcarouter/...' requires ${ORCAROUTER_API_KEY_ENV} or an "
+            "api_key passed via llm_params"
+        )
+    kwargs["api_key"] = key
+    return kwargs
+
+
 def _base_kwargs(
     model: str,
     retries: int,
@@ -43,6 +69,8 @@ def _base_kwargs(
 ) -> dict[str, Any]:
     # `params` first so datachain.llm's own keys always win.
     kwargs: dict[str, Any] = {**params, "model": model, "num_retries": max(retries, 0)}
+    if model.startswith("orcarouter/"):
+        kwargs.update(_orcarouter_kwargs(kwargs))
     if (fallbacks := _fallbacks(fallback)) is not None:
         kwargs["fallbacks"] = fallbacks
     return kwargs

--- a/tests/unit/lib/test_llm.py
+++ b/tests/unit/lib/test_llm.py
@@ -855,3 +855,49 @@ def test_content_raises_on_no_message():
 
 def test_finish_reason_empty_on_no_choices():
     assert engine._finish_reason(types.SimpleNamespace(choices=[])) == ""
+
+
+def test_orcarouter_model_injects_gateway_kwargs(fake_llm, monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    bind(llm.complete("t"), llm="orcarouter/auto")("hi")
+    call = fake_llm.calls[-1]
+    assert call["model"] == "orcarouter/auto"
+    assert call["api_base"] == "https://api.orcarouter.ai/v1"
+    assert call["api_key"] == "sk-orca-test"
+    assert call["custom_llm_provider"] == "openai"
+
+
+def test_orcarouter_key_from_llm_params(fake_llm):
+    bind(llm.complete("t"), llm="orcarouter/auto", llm_params={"api_key": "K"})("hi")
+    assert fake_llm.calls[-1]["api_key"] == "K"
+
+
+def test_orcarouter_key_prefers_params_over_env(fake_llm, monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "ENV")
+    bind(llm.complete("t"), llm="orcarouter/auto", llm_params={"api_key": "PARAM"})(
+        "hi"
+    )
+    assert fake_llm.calls[-1]["api_key"] == "PARAM"
+
+
+def test_orcarouter_missing_key_raises(fake_llm, monkeypatch):
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+    with pytest.raises(engine.LLMError, match="ORCAROUTER_API_KEY"):
+        bind(llm.complete("t"), llm="orcarouter/auto")("hi")
+
+
+def test_orcarouter_embed_injects_gateway_kwargs(fake_llm, monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    bind(llm.embed("t"), llm="orcarouter/auto")("hi")
+    call = fake_llm.embedding_calls[-1]
+    assert call["model"] == "orcarouter/auto"
+    assert call["api_base"] == "https://api.orcarouter.ai/v1"
+    assert call["api_key"] == "sk-orca-test"
+    assert call["custom_llm_provider"] == "openai"
+
+
+def test_non_orcarouter_model_unaffected(fake_llm):
+    bind(llm.complete("t"), llm="anthropic/claude-haiku-4-5")("hi")
+    call = fake_llm.calls[-1]
+    assert "custom_llm_provider" not in call
+    assert "api_base" not in call


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a named LLM provider in `datachain.llm`.

OrcaRouter is an OpenAI-compatible gateway at `https://api.orcarouter.ai/v1`. A model
string of `orcarouter/<model>` now routes through the existing LiteLLM path as an
OpenAI-compatible chat/embedding request, using the `ORCAROUTER_API_KEY` credential
(or an `api_key` passed via `llm_params`). Its `orcarouter/auto` alias selects a
default model automatically.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint —
screening every prompt/response and governing every tool call on a default-deny basis,
with no application code changes.

### Changes

- `src/datachain/llm/engine.py`: detect the `orcarouter/` prefix in `_base_kwargs` and
  inject `api_base=https://api.orcarouter.ai/v1`, `custom_llm_provider="openai"`, and
  the resolved API key. An explicit key is required (env `ORCAROUTER_API_KEY` or via
  `llm_params`), so an unrelated `OPENAI_API_KEY` is never sent to the gateway; a
  missing key raises a clear `LLMError`.
- `tests/unit/lib/test_llm.py`: unit tests covering the injected kwargs (chat and
  embedding), env vs `llm_params` key precedence, the missing-key error, and that
  non-OrcaRouter models are unaffected.
- `docs/references/llm.md`: document the `orcarouter/<model>` provider.

### Verification

- `pytest tests/unit/lib/test_llm.py tests/func/test_llm.py tests/unit/lib/test_settings.py`
  → 170 passed.
- `ruff check` and `ruff format --check` clean on changed files; `mypy` clean on `engine.py`.
- `mkdocs build` succeeds.
- Live: a real chain using `settings(llm="orcarouter/auto", llm_params={"api_key": ...})`
  hit `https://api.orcarouter.ai/v1` and returned a chat reply (`ORCA-OK`) and a 3072-dim
  embedding.

Disclosure: I'm an engineer on the OrcaRouter team.
