### PR TITLE
fix: restore plain Pydantic model identities

### DIFF
--- a/src/datachain/lib/signal_schema.py
+++ b/src/datachain/lib/signal_schema.py
@@ -2,6 +2,7 @@ import copy
 import hashlib
 import logging
 import math
+import sys
 import types
 import warnings
 import weakref
@@ -440,6 +441,98 @@ class SignalSchema:
         return subtypes
 
     @staticmethod
+    def _custom_type_matches_model(  # noqa: PLR0911
+        model: type[BaseModel],
+        custom_type: CustomType,
+        custom_types: dict[str, Any],
+        seen: set[tuple[type[BaseModel], str]] | None = None,
+    ) -> bool:
+        if set(model.model_fields) != set(custom_type.fields):
+            return False
+        if custom_type.bases and SignalSchema._get_bases(model) != custom_type.bases:
+            return False
+        if custom_type.hidden_fields != getattr(model, "_hidden_fields", []):
+            return False
+        if custom_type.partial_fingerprint != getattr(
+            model, "_partial_fingerprint", None
+        ):
+            return False
+
+        if seen is None:
+            seen = set()
+        key = (model, custom_type.name)
+        if key in seen:
+            return True
+        seen.add(key)
+
+        for field_name, field_info in model.model_fields.items():
+            field_subtypes: list[Any] = []
+            serialized_field = type_to_str(
+                field_info.annotation,
+                field_subtypes,
+                register_pydantic=False,
+            )
+            if custom_type.fields[field_name] != serialized_field:
+                return False
+
+            for subtype in field_subtypes:
+                if not ModelStore.is_pydantic(subtype):
+                    continue
+                subtype_name = ModelStore.get_name(subtype)
+                subtype_data = custom_types.get(subtype_name)
+                if subtype_data is None:
+                    return False
+                try:
+                    subtype_schema = CustomType.deserialize(subtype_data, subtype_name)
+                except ValidationError:
+                    return False
+                if not SignalSchema._custom_type_matches_model(
+                    subtype, subtype_schema, custom_types, seen
+                ):
+                    return False
+
+        return True
+
+    @staticmethod
+    def _find_loaded_custom_type(
+        custom_type: CustomType, custom_types: dict[str, Any]
+    ) -> type[BaseModel] | None:
+        if not custom_type.bases or custom_type.bases[0][2] is not None:
+            return None
+
+        class_name, module_name, _ = custom_type.bases[0]
+        module = sys.modules.get(module_name)
+        candidate = getattr(module, class_name, None) if module is not None else None
+        if ModelStore.is_pydantic(candidate):
+            if SignalSchema._custom_type_matches_model(
+                candidate, custom_type, custom_types
+            ):
+                return candidate
+            warnings.warn(
+                f"loaded Pydantic model '{module_name}.{class_name}' does not match "
+                "the stored schema; rebuilding it",
+                SignalSchemaWarning,
+                stacklevel=3,
+            )
+
+        pending = list(BaseModel.__subclasses__())
+        seen: set[type[BaseModel]] = set()
+        while pending:
+            candidate = pending.pop()
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            pending.extend(candidate.__subclasses__())
+            if candidate.__name__ != class_name or candidate.__module__ != module_name:
+                continue
+            if SignalSchema._custom_type_matches_model(
+                candidate, custom_type, custom_types
+            ):
+                return candidate
+
+        return None
+
+    @staticmethod
     def _deserialize_custom_type(
         type_name: str, custom_types: dict[str, Any]
     ) -> type | None:
@@ -457,6 +550,9 @@ class SignalSchema:
                 ) from exc
 
             if fr := ModelStore.get(model_name, target_version):
+                return fr
+
+            if fr := SignalSchema._find_loaded_custom_type(ct, custom_types):
                 return fr
 
             fields = {

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1,5 +1,8 @@
+import gc
 import json
 import pickle
+import subprocess
+import sys
 from collections import UserDict, UserList
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import datetime
@@ -16,7 +19,7 @@ from typing import (
 )
 
 import pytest
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError, create_model
 from typing_extensions import TypedDict
 
 from datachain import Column, DataModel, Sys, func
@@ -94,6 +97,14 @@ class MyTypeComplexOld(DataModel):
     name: str
     items: list[MyType1]
     lookup: dict[str, MyType2]
+
+
+class ImportedThresholds(BaseModel):
+    minimum: float
+
+
+class ImportedScenario(BaseModel):
+    thresholds: ImportedThresholds
 
 
 def test_deserialize_basic():
@@ -789,6 +800,87 @@ def test_deserialize_restores_known_base_type():
     deserialized_schema = SignalSchema.deserialize(signals)
     assert deserialized_schema.values["fr"].__name__ == "MyType3_v1"
     assert issubclass(deserialized_schema.values["fr"], MyType1)
+
+
+def test_deserialize_reuses_imported_plain_pydantic_models(monkeypatch):
+    serialized = SignalSchema({"scenario": ImportedScenario}).serialize()
+    monkeypatch.setattr(ModelStore, "store", {})
+
+    restored = SignalSchema.deserialize(serialized)
+    restored_model = restored.values["scenario"]
+
+    assert restored_model is ImportedScenario
+    scenario = restored_model(thresholds={"minimum": 0.5})
+    assert isinstance(scenario, ImportedScenario)
+    assert isinstance(scenario.thresholds, ImportedThresholds)
+
+
+def test_deserialize_reuses_imported_plain_pydantic_models_in_new_process():
+    serialized = SignalSchema({"scenario": ImportedScenario}).serialize()
+    script = """
+import json
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+from datachain.lib.signal_schema import SignalSchema
+
+module_name = "tests.unit.lib.test_signal_schema"
+spec = spec_from_file_location(
+    module_name, Path(sys.argv[1])
+)
+module = module_from_spec(spec)
+sys.modules[module_name] = module
+spec.loader.exec_module(module)
+
+schema = SignalSchema.deserialize(json.loads(sys.stdin.read()))
+assert schema.values["scenario"] is module.ImportedScenario
+scenario = schema.values["scenario"](thresholds={"minimum": 0.5})
+assert isinstance(scenario.thresholds, module.ImportedThresholds)
+"""
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script, __file__],
+        input=json.dumps(serialized),
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_deserialize_reuses_local_plain_pydantic_model(monkeypatch):
+    class LocalPlainModel(BaseModel):
+        value: int
+
+    serialized = SignalSchema({"model": LocalPlainModel}).serialize()
+    monkeypatch.setattr(ModelStore, "store", {})
+
+    restored = SignalSchema.deserialize(serialized)
+
+    assert restored.values["model"] is LocalPlainModel
+
+
+def test_deserialize_rebuilds_plain_model_when_loaded_fields_do_not_match(monkeypatch):
+    source_model = create_model("ImportedModel", value=(int, ...))
+    source_model.__module__ = __name__
+    serialized = SignalSchema({"model": source_model}).serialize()
+    monkeypatch.setattr(ModelStore, "store", {})
+
+    loaded_model = create_model("ImportedModel", value=(str, ...))
+    loaded_model.__module__ = __name__
+    monkeypatch.setattr(
+        sys.modules[__name__], "ImportedModel", loaded_model, raising=False
+    )
+    del source_model
+    gc.collect()
+
+    with pytest.warns(SignalSchemaWarning, match="does not match"):
+        restored = SignalSchema.deserialize(serialized).values["model"]
+
+    assert restored is not loaded_model
+    assert restored.model_fields["value"].annotation is int
 
 
 def test_deserialize_custom_type_bad_schema():


### PR DESCRIPTION
Fixes #1910.

When a dataset schema is read in a fresh process, plain Pydantic models are not registered in `ModelStore`, so the schema previously rebuilt same-named dynamic models. This restores an already loaded original model only when its stored field specification (including nested Pydantic models) matches.

The resolver only inspects `sys.modules` and existing `BaseModel` subclasses; it never imports a module named by dataset metadata. A same-named model with a mismatched schema is rejected with a warning and the existing dynamic rebuild path is retained.

Tests:
- `pytest tests/unit/lib/test_signal_schema.py -q`
- `ruff check src/datachain/lib/signal_schema.py tests/unit/lib/test_signal_schema.py`
- `ruff format --check src/datachain/lib/signal_schema.py tests/unit/lib/test_signal_schema.py`

This complements #1877, which handles conflicting already-registered models.