### PR TITLE
Fix job log blob fetching: drop auth header on presigned URLs, pass bytes through

### DIFF
--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -426,6 +426,8 @@ async def _show_log_blobs(log_blobs: list[str], client):
                 if not log_content.endswith(b"\n"):
                     sys.stdout.buffer.write(b"\n")
                 sys.stdout.buffer.flush()
+        except BrokenPipeError:
+            raise
         except (requests.RequestException, OSError) as exc:
             response = getattr(exc, "response", None)
             detail = (

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -406,7 +406,7 @@ def parse_start_time(start_time_str: str | None) -> str | None:
 
 # Sync usage
 async def _fetch_log_blob(blob_url: str, timeout: float) -> bytes:
-    """Fetch log content from a blob URL asynchronously."""
+    """Return the log blob content as bytes."""
 
     def _fetch():
         response = requests.get(blob_url, timeout=timeout)

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -405,14 +405,13 @@ def parse_start_time(start_time_str: str | None) -> str | None:
 
 
 # Sync usage
-async def _fetch_log_blob(blob_url: str, token: str, timeout: float) -> str:
+async def _fetch_log_blob(blob_url: str, timeout: float) -> bytes:
     """Fetch log content from a blob URL asynchronously."""
 
     def _fetch():
-        headers = {"Authorization": f"token {token}"}
-        response = requests.get(blob_url, headers=headers, timeout=timeout)
+        response = requests.get(blob_url, timeout=timeout)
         response.raise_for_status()
-        return response.text
+        return response.content
 
     return await asyncio.to_thread(_fetch)
 
@@ -420,11 +419,18 @@ async def _fetch_log_blob(blob_url: str, token: str, timeout: float) -> str:
 async def _show_log_blobs(log_blobs: list[str], client):
     for blob_url in log_blobs:
         try:
-            log_content = await _fetch_log_blob(blob_url, client.token, client.timeout)
+            log_content = await _fetch_log_blob(blob_url, client.timeout)
             if log_content:
-                print(log_content, end="")
-        except (requests.RequestException, OSError):
-            print("\n>>>> Warning: Failed to fetch logs from studio")
+                sys.stdout.flush()
+                sys.stdout.buffer.write(log_content)
+                if not log_content.endswith(b"\n"):
+                    sys.stdout.buffer.write(b"\n")
+                sys.stdout.buffer.flush()
+        except (requests.RequestException, OSError) as exc:
+            print(f"\n>>>> Warning: Failed to fetch logs from studio: {exc}")
+            response = getattr(exc, "response", None)
+            if response is not None and response.text:
+                logger.debug("Log blob fetch failed, response body: %s", response.text)
 
 
 def _get_job_status(client, job_id: str) -> str | None:

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -427,8 +427,13 @@ async def _show_log_blobs(log_blobs: list[str], client):
                     sys.stdout.buffer.write(b"\n")
                 sys.stdout.buffer.flush()
         except (requests.RequestException, OSError) as exc:
-            print(f"\n>>>> Warning: Failed to fetch logs from studio: {exc}")
             response = getattr(exc, "response", None)
+            detail = (
+                f"HTTP {response.status_code}"
+                if response is not None
+                else type(exc).__name__
+            )
+            print(f"\n>>>> Warning: Failed to fetch logs from studio ({detail})")
             if response is not None and response.text:
                 logger.debug("Log blob fetch failed, response body: %s", response.text)
 

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -1449,7 +1449,7 @@ def test_studio_run_log_blobs_http_error_detail(
     job_id = str(uuid.uuid4())
 
     async def mock_tail_job_logs(jid, no_follow=False):
-        yield {"log_blobs": ["https://example.com/blob1"]}
+        yield {"log_blobs": ["https://example.com/blob1?X-Amz-Signature=secretsig"]}
         yield {"job": {"status": "COMPLETE"}}
 
     mocker.patch(
@@ -1471,7 +1471,7 @@ def test_studio_run_log_blobs_http_error_detail(
             json={"dataset_versions": []},
         )
         m.get(
-            "https://example.com/blob1",
+            "https://example.com/blob1?X-Amz-Signature=secretsig",
             status_code=400,
             text="<Error><Code>InvalidArgument</Code></Error>",
         )
@@ -1484,7 +1484,8 @@ def test_studio_run_log_blobs_http_error_detail(
         assert exit_code == 0
 
     out = capsys.readouterr().out
-    assert "Warning: Failed to fetch logs from studio: 400" in out
+    assert "Warning: Failed to fetch logs from studio (HTTP 400)" in out
+    assert "secretsig" not in out
     assert "<Error><Code>InvalidArgument</Code></Error>" in caplog.text
 
 

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import re
@@ -1487,6 +1488,17 @@ def test_studio_run_log_blobs_http_error_detail(
     assert "Warning: Failed to fetch logs from studio (HTTP 400)" in out
     assert "secretsig" not in out
     assert "<Error><Code>InvalidArgument</Code></Error>" in caplog.text
+
+
+def test_show_log_blobs_propagates_broken_pipe(mocker):
+    from datachain.studio import _show_log_blobs
+
+    mocker.patch("datachain.studio._fetch_log_blob", return_value=b"content\n")
+    stdout = mocker.patch("datachain.studio.sys.stdout")
+    stdout.buffer.write.side_effect = BrokenPipeError
+
+    with pytest.raises(BrokenPipeError):
+        asyncio.run(_show_log_blobs(["https://example.com/blob1"], mocker.MagicMock()))
 
 
 def test_studio_run_log_blobs_fetch_failure(capsys, mocker, tmp_dir, studio_token):

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -1361,7 +1361,7 @@ def test_studio_run_log_blobs(capsys, mocker, tmp_dir, studio_token):
     )
     mocker.patch(
         "datachain.studio._fetch_log_blob",
-        return_value="fetched log content\n",
+        return_value=b"fetched log content\n",
     )
 
     with requests_mock.mock() as m:
@@ -1386,6 +1386,106 @@ def test_studio_run_log_blobs(capsys, mocker, tmp_dir, studio_token):
 
     out = capsys.readouterr().out
     assert "fetched log content" in out
+
+
+def test_studio_run_log_blobs_fetches_presigned_utf8(
+    capsys, mocker, tmp_dir, studio_token
+):
+    job_id = str(uuid.uuid4())
+
+    async def mock_tail_job_logs(jid, no_follow=False):
+        yield {
+            "log_blobs": [
+                "https://example.com/blob1",
+                "https://example.com/blob2",
+            ]
+        }
+        yield {"job": {"status": "COMPLETE"}}
+
+    mocker.patch(
+        "datachain.studio.StudioClient.tail_job_logs",
+        side_effect=mock_tail_job_logs,
+    )
+
+    with requests_mock.mock() as m:
+        m.post(
+            f"{STUDIO_URL}/api/datachain/jobs/",
+            json={"id": job_id, "url": "https://example.com"},
+        )
+        m.get(
+            re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
+            json=[{"status": "COMPLETE"}],
+        )
+        m.get(
+            f"{STUDIO_URL}/api/datachain/datasets/dataset_job_versions?job_id={job_id}&team_name=team_name",
+            json={"dataset_versions": []},
+        )
+        blob1 = m.get(
+            "https://example.com/blob1",
+            content="signal at 5 μS".encode(),
+            headers={"Content-Type": "text/plain"},
+        )
+        blob2 = m.get(
+            "https://example.com/blob2",
+            content=b"second blob\n",
+            headers={"Content-Type": "text/plain"},
+        )
+
+        (tmp_dir / "example_query.py").write_text("print(1)")
+
+        exit_code = main(["job", "run", "example_query.py"])
+
+        assert exit_code == 0
+        assert "Authorization" not in blob1.last_request.headers
+        assert "Authorization" not in blob2.last_request.headers
+
+    out = capsys.readouterr().out
+    assert "signal at 5 μS\nsecond blob\n" in out
+
+
+def test_studio_run_log_blobs_http_error_detail(
+    capsys, caplog, mocker, tmp_dir, studio_token
+):
+    job_id = str(uuid.uuid4())
+
+    async def mock_tail_job_logs(jid, no_follow=False):
+        yield {"log_blobs": ["https://example.com/blob1"]}
+        yield {"job": {"status": "COMPLETE"}}
+
+    mocker.patch(
+        "datachain.studio.StudioClient.tail_job_logs",
+        side_effect=mock_tail_job_logs,
+    )
+
+    with requests_mock.mock() as m:
+        m.post(
+            f"{STUDIO_URL}/api/datachain/jobs/",
+            json={"id": job_id, "url": "https://example.com"},
+        )
+        m.get(
+            re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
+            json=[{"status": "COMPLETE"}],
+        )
+        m.get(
+            f"{STUDIO_URL}/api/datachain/datasets/dataset_job_versions?job_id={job_id}&team_name=team_name",
+            json={"dataset_versions": []},
+        )
+        m.get(
+            "https://example.com/blob1",
+            status_code=400,
+            text="<Error><Code>InvalidArgument</Code></Error>",
+        )
+
+        (tmp_dir / "example_query.py").write_text("print(1)")
+
+        with caplog.at_level(logging.DEBUG, logger="datachain"):
+            exit_code = main(["job", "run", "-v", "example_query.py"])
+
+        assert exit_code == 0
+
+    out = capsys.readouterr().out
+    assert "Warning: Failed to fetch logs from studio: 400" in out
+    assert "<Error><Code>InvalidArgument</Code></Error>" in caplog.text
 
 
 def test_studio_run_log_blobs_fetch_failure(capsys, mocker, tmp_dir, studio_token):

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -1389,8 +1389,8 @@ def test_studio_run_log_blobs(capsys, mocker, tmp_dir, studio_token):
     assert "fetched log content" in out
 
 
-def test_studio_run_log_blobs_fetches_presigned_utf8(
-    capsys, mocker, tmp_dir, studio_token
+def test_studio_run_log_blobs_fetches_presigned_bytes(
+    capsysbinary, mocker, tmp_dir, studio_token
 ):
     job_id = str(uuid.uuid4())
 
@@ -1423,7 +1423,7 @@ def test_studio_run_log_blobs_fetches_presigned_utf8(
         )
         blob1 = m.get(
             "https://example.com/blob1",
-            content="signal at 5 μS".encode(),
+            content=b"signal:\xff at 5 \xc2\xb5S",
             headers={"Content-Type": "text/plain"},
         )
         blob2 = m.get(
@@ -1440,8 +1440,8 @@ def test_studio_run_log_blobs_fetches_presigned_utf8(
         assert "Authorization" not in blob1.last_request.headers
         assert "Authorization" not in blob2.last_request.headers
 
-    out = capsys.readouterr().out
-    assert "signal at 5 μS\nsecond blob\n" in out
+    out = capsysbinary.readouterr().out
+    assert b"signal:\xff at 5 \xc2\xb5S\nsecond blob\n" in out
 
 
 def test_studio_run_log_blobs_http_error_detail(


### PR DESCRIPTION
Reported by a user diagnosing a production incident: `datachain job logs` returned no log content for any job whose logs had been archived to blob storage — only `>>>> Warning: Failed to fetch logs from studio`.

Three bugs in `_fetch_log_blob` / `_show_log_blobs`:

1. **An `Authorization` header was attached to presigned S3 URLs.** S3 rejects a request carrying both a query-string signature and an `Authorization` header with `400 InvalidArgument`, so every blob fetch failed. The header is removed (the URL itself is the credential), along with the now-unused `token` parameter.
2. **`response.text` corrupted the log.** S3 serves blobs as `text/plain` with no charset, so `requests` fell back to ISO-8859-1 and mangled every non-ASCII byte. Blob content is now passed through to stdout as raw bytes, with no decode/encode round-trip at all — so `datachain job logs > file` reproduces the archived log byte-exactly. See also note about buffered download VS streaming.
3. **Blobs were concatenated without a newline at the boundary**, gluing the last record of one blob to the first record of the next. A newline is added when a blob doesn't end with one.

Additionally, the generic warning previously swallowed the real cause. It now includes the exception (status code and URL), and the response body is logged at debug level, so `datachain job logs -v` shows the server's error message (e.g. the S3 `InvalidArgument` body above).

#### Buffered download VS streaming

`requests.get` without `stream=True` holds the whole blob in memory (e.g. 42 MB). Streaming via `iter_content` was considered and rejected.

Streaming **pros**:
- constant memory regardless of blob size;
- earlier time-to-first-byte (output starts while downloading);
- a mid-transfer failure still yields the partial log instead of nothing.

Streaming **cons**:
- with `datachain job logs | less`, pipe backpressure blocks the write while the presigned S3 GET sits open; idle/expiry limits can kill the connection and truncate the log — and the request `timeout` can't help, since it guards socket reads while we'd be blocked on a write. Buffered mode is immune: the download completes in seconds, then the pipe can be arbitrarily slow. Piping to `less`/`grep` is exactly the forensic workflow this fix serves. There are workarounds, but let's keep it simple for now, we can always improve it in a future follow-ups if needed.