### PR TITLE
Require anthropic 1.0+ in examples and drop the removed temperature argument

### DIFF
--- a/examples/llm_and_nlp/claude-query.py
+++ b/examples/llm_and_nlp/claude-query.py
@@ -9,7 +9,6 @@ from datachain import C, File
 
 DATA = "gs://datachain-demo/chatbot-KiT"
 MODEL = "claude-sonnet-4-5"
-TEMPERATURE = 0.9
 DEFAULT_OUTPUT_TOKENS = 1024
 
 PROMPT = """Consider the dialogue between the 'user' and the 'bot'. The 'user' is a
@@ -42,7 +41,6 @@ def rate(client: anthropic.Anthropic, file: File) -> Rating:
         model=MODEL,
         max_tokens=DEFAULT_OUTPUT_TOKENS,
         system=PROMPT,
-        temperature=TEMPERATURE,
         messages=[
             {"role": "user", "content": f"{content}"},
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ examples = [
   "datachain[tests]",
   "defusedxml",
   "accelerate",
-  "anthropic",
+  "anthropic>=1.0.0",
   "huggingface_hub[hf_transfer]",
   "transformers>=5.0.0",
   "ultralytics",


### PR DESCRIPTION
The `examples (llm_and_nlp)` CI job [started failing](https://github.com/datachain-ai/datachain/actions/runs/32737542022/job/97464243414?pr=1953) once `anthropic` 1.0.0 landed on PyPI:

```
TypeError: Messages.parse() got an unexpected keyword argument 'temperature'
```

The `examples` extra pinned `anthropic` with no bound, so CI picked up the new major
version. Anthropic removed `temperature` (along with `top_p`/`top_k`) from the Messages
API in 1.0.0 — it is gone from `messages.create`, `beta.messages.create`, and
`beta.messages.parse` alike — and `examples/llm_and_nlp/claude-query.py` was still
passing it.

Two changes:

- `pyproject.toml` — the `examples` extra now requires `anthropic>=1.0.0`, so the
  example is checked against the API it actually targets instead of whatever version
  happens to resolve.
- `examples/llm_and_nlp/claude-query.py` — removed the `temperature=TEMPERATURE`
  argument and the now-unused `TEMPERATURE` constant.

<sub>🤖 Co-authored by Claude Code and ChatGPT</sub>