### PR TITLE
Report Studio's terminal websocket errors instead of reconnecting silently

### DIFF
--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -327,9 +327,9 @@ class StudioClient:
                         logger.error("Error receiving websocket message: %s", e)
                         break
         except (websockets.exceptions.WebSocketException, OSError) as e:
-            # Studio rejects the handshake with 403 for an unknown team, an
-            # invalid token, or a missing job_id; retrying cannot fix those.
-            # Any other status (a 5xx from a gateway mid-deploy) is transient.
+            # An auth refusal (401, 403) is terminal: the same request will be
+            # refused again. Any other status (a 5xx from a gateway mid-deploy)
+            # is worth another attempt.
             response = getattr(e, "response", None)
             status = getattr(response, "status_code", None) or getattr(
                 e, "status_code", None

--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -327,6 +327,19 @@ class StudioClient:
                         logger.error("Error receiving websocket message: %s", e)
                         break
         except (websockets.exceptions.WebSocketException, OSError) as e:
+            # Studio rejects the handshake with 403 for an unknown team, an
+            # invalid token, or a missing job_id; retrying cannot fix those.
+            # Any other status (a 5xx from a gateway mid-deploy) is transient.
+            response = getattr(e, "response", None)
+            status = getattr(response, "status_code", None) or getattr(
+                e, "status_code", None
+            )
+            if status in (401, 403):
+                raise DataChainError(
+                    f"Studio refused the log stream connection (HTTP {status})."
+                    f" Check the team name ({self.team}) and your token."
+                ) from e
+
             logger.debug("WebSocket connection failed: %s", e)
             return
 

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -476,6 +476,27 @@ def _process_logs_message(
     return received, last_log_id
 
 
+async def _wait_before_reconnect(retry_count: int) -> str:
+    sleep_sec = min(
+        RECONNECT_BACKOFF_BASE_SEC * 2**retry_count,
+        RECONNECT_BACKOFF_MAX_SEC,
+    ) + random.uniform(0, 1)  # noqa: S311
+    logger.debug(
+        "WebSocket closed, reconnecting in %.1fs (attempt %d/%d)",
+        sleep_sec,
+        retry_count + 1,
+        RECONNECT_MAX_ATTEMPTS,
+    )
+    msg = _print_reconnect_msg(sleep_sec)
+    try:
+        await asyncio.sleep(sleep_sec)
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        _clear_line(msg)
+        raise
+
+    return msg
+
+
 def show_logs_from_client(  # noqa: C901
     client, job_id: str, no_follow: bool = False
 ):
@@ -487,8 +508,12 @@ def show_logs_from_client(  # noqa: C901
         while True:
             received_streaming_data = False
             session_start_id = last_log_id
+            reconnect_msg = _clear_line(reconnect_msg)
             async for message in client.tail_job_logs(job_id, no_follow=no_follow):
-                reconnect_msg = _clear_line(reconnect_msg)
+                # A bare {"message": ...} frame is Studio's terminal error.
+                if "message" in message:
+                    raise DataChainError(message["message"])
+
                 if "log_blobs" in message and not no_follow:
                     log_blobs = message.get("log_blobs", [])
                     if log_blobs and not log_blobs_processed:
@@ -525,19 +550,8 @@ def show_logs_from_client(  # noqa: C901
                 if retry_count >= RECONNECT_MAX_ATTEMPTS:
                     logger.debug("Max reconnect attempts reached: %d", retry_count)
                     break
-                sleep_sec = min(
-                    RECONNECT_BACKOFF_BASE_SEC * 2**retry_count,
-                    RECONNECT_BACKOFF_MAX_SEC,
-                ) + random.uniform(0, 1)  # noqa: S311
+                reconnect_msg = await _wait_before_reconnect(retry_count)
                 retry_count += 1
-                logger.debug(
-                    "WebSocket closed, reconnecting in %.1fs (attempt %d/%d)",
-                    sleep_sec,
-                    retry_count,
-                    RECONNECT_MAX_ATTEMPTS,
-                )
-                reconnect_msg = _print_reconnect_msg(sleep_sec)
-                await asyncio.sleep(sleep_sec)
             except KeyError:
                 break
 

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -1751,6 +1751,173 @@ def test_studio_run_reconnect_resets_counter_on_streaming_data(
     assert "Max reconnect attempts reached:" in caplog.text
 
 
+def test_studio_job_logs_refused_handshake_aborts(capsys, mocker, studio_token):
+    from websockets.datastructures import Headers
+    from websockets.http11 import Response
+
+    def mock_connect(url, additional_headers):
+        raise websockets.exceptions.InvalidStatus(Response(403, "Forbidden", Headers()))
+
+    mocker.patch("datachain.remote.studio.websockets.connect", side_effect=mock_connect)
+    mocker.patch("datachain.studio.RECONNECT_MAX_ATTEMPTS", 0)
+
+    with requests_mock.mock() as m:
+        m.get(
+            re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
+            json=[{"status": "RUNNING"}],
+        )
+
+        exit_code = main(["job", "logs", str(uuid.uuid4())])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Studio refused the log stream connection (HTTP 403)" in captured.err
+    assert "team_name" in captured.err
+    assert "reconnecting in" not in captured.out
+
+
+def test_studio_job_logs_transient_handshake_failure_retries(
+    capsys, mocker, studio_token
+):
+    from websockets.datastructures import Headers
+    from websockets.http11 import Response
+
+    def mock_connect(url, additional_headers):
+        raise websockets.exceptions.InvalidStatus(
+            Response(503, "Service Unavailable", Headers())
+        )
+
+    mocker.patch("datachain.remote.studio.websockets.connect", side_effect=mock_connect)
+    mocker.patch("datachain.studio.RECONNECT_MAX_ATTEMPTS", 0)
+
+    with requests_mock.mock() as m:
+        m.get(
+            re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
+            json=[{"status": "COMPLETE"}],
+        )
+        m.get(
+            re.compile(
+                rf"^{re.escape(STUDIO_URL)}/api/datachain/datasets/dataset_job_versions"
+            ),
+            json={"dataset_versions": []},
+        )
+
+        exit_code = main(["job", "logs", str(uuid.uuid4())])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert ">>>> Job is now in COMPLETE status." in captured.out
+    assert "refused the log stream connection" not in captured.err
+
+
+def test_studio_job_logs_terminal_error_on_reconnect_clears_banner(
+    capsys, mocker, studio_token
+):
+    from websockets.datastructures import Headers
+    from websockets.http11 import Response
+
+    statuses = [503, 403]
+
+    def mock_connect(url, additional_headers):
+        raise websockets.exceptions.InvalidStatus(
+            Response(statuses.pop(0), "", Headers())
+        )
+
+    mocker.patch("datachain.remote.studio.websockets.connect", side_effect=mock_connect)
+    mocker.patch("datachain.studio.RECONNECT_BACKOFF_BASE_SEC", 0)
+
+    with requests_mock.mock() as m:
+        m.get(
+            re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
+            json=[{"status": "RUNNING"}],
+        )
+
+        exit_code = main(["job", "logs", str(uuid.uuid4())])
+
+    assert exit_code == 1
+    assert not statuses
+    captured = capsys.readouterr()
+    assert "Studio refused the log stream connection (HTTP 403)" in captured.err
+    assert "reconnecting in" in captured.out
+    assert re.search(r" {10,}\r", captured.out)
+
+
+def test_studio_job_logs_interrupt_during_backoff_clears_banner(
+    capsys, mocker, studio_token
+):
+    async def mock_tail_job_logs(jid, no_follow=False):
+        return
+        yield
+
+    mocker.patch(
+        "datachain.studio.StudioClient.tail_job_logs",
+        side_effect=mock_tail_job_logs,
+    )
+    mocker.patch("datachain.studio.asyncio.sleep", side_effect=KeyboardInterrupt)
+
+    with requests_mock.mock() as m:
+        m.get(
+            re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
+            json=[{"status": "RUNNING"}],
+        )
+
+        exit_code = main(["job", "logs", str(uuid.uuid4())])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "reconnecting in" in captured.out
+    assert re.search(r" {10,}\r", captured.out)
+    assert "Operation cancelled by the user" in captured.err
+
+
+def test_studio_job_logs_legacy_status_code_attribute_aborts(
+    capsys, mocker, studio_token
+):
+    class LegacyInvalidStatusCode(websockets.exceptions.WebSocketException):
+        status_code = 403
+
+    def mock_connect(url, additional_headers):
+        raise LegacyInvalidStatusCode
+
+    mocker.patch("datachain.remote.studio.websockets.connect", side_effect=mock_connect)
+    mocker.patch("datachain.studio.RECONNECT_MAX_ATTEMPTS", 0)
+
+    with requests_mock.mock() as m:
+        m.get(
+            re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
+            json=[{"status": "RUNNING"}],
+        )
+
+        exit_code = main(["job", "logs", str(uuid.uuid4())])
+
+    assert exit_code == 1
+    assert "HTTP 403" in capsys.readouterr().err
+
+
+def test_studio_job_logs_server_error_frame_aborts(capsys, mocker, studio_token):
+    async def mock_tail_job_logs(jid, no_follow=False):
+        yield {"message": "Job ID is incorrect or not found"}
+
+    mocker.patch(
+        "datachain.studio.StudioClient.tail_job_logs",
+        side_effect=mock_tail_job_logs,
+    )
+    mocker.patch("datachain.studio.RECONNECT_MAX_ATTEMPTS", 0)
+
+    with requests_mock.mock() as m:
+        m.get(
+            re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
+            json=[{"status": "RUNNING"}],
+        )
+
+        exit_code = main(["job", "logs", str(uuid.uuid4())])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Job ID is incorrect or not found" in captured.err
+    assert "Failed to reconnect" not in captured.out
+
+
 def test_unpacker_hook_unknown_ext_type():
     import msgpack
 

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -1787,13 +1787,19 @@ def test_studio_job_logs_transient_handshake_failure_retries(
     def mock_connect(url, additional_headers):
         raise InvalidStatus(Response(503, "Service Unavailable", Headers()))
 
-    mocker.patch("datachain.remote.studio.websockets.connect", side_effect=mock_connect)
-    mocker.patch("datachain.studio.RECONNECT_MAX_ATTEMPTS", 0)
+    connect = mocker.patch(
+        "datachain.remote.studio.websockets.connect", side_effect=mock_connect
+    )
+    mocker.patch("datachain.studio.RECONNECT_MAX_ATTEMPTS", 1)
+    mocker.patch("datachain.studio.asyncio.sleep")
 
     with requests_mock.mock() as m:
         m.get(
             re.compile(rf"^{re.escape(STUDIO_URL)}/api/datachain/jobs/"),
-            json=[{"status": "COMPLETE"}],
+            [
+                {"json": [{"status": "RUNNING"}]},
+                {"json": [{"status": "COMPLETE"}]},
+            ],
         )
         m.get(
             re.compile(
@@ -1805,7 +1811,9 @@ def test_studio_job_logs_transient_handshake_failure_retries(
         exit_code = main(["job", "logs", str(uuid.uuid4())])
 
     assert exit_code == 0
+    assert connect.call_count == 2
     captured = capsys.readouterr()
+    assert ">>>> Job is now in RUNNING status." in captured.out
     assert ">>>> Job is now in COMPLETE status." in captured.out
     assert "refused the log stream connection" not in captured.err
 

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -1753,10 +1753,11 @@ def test_studio_run_reconnect_resets_counter_on_streaming_data(
 
 def test_studio_job_logs_refused_handshake_aborts(capsys, mocker, studio_token):
     from websockets.datastructures import Headers
+    from websockets.exceptions import InvalidStatus
     from websockets.http11 import Response
 
     def mock_connect(url, additional_headers):
-        raise websockets.exceptions.InvalidStatus(Response(403, "Forbidden", Headers()))
+        raise InvalidStatus(Response(403, "Forbidden", Headers()))
 
     mocker.patch("datachain.remote.studio.websockets.connect", side_effect=mock_connect)
     mocker.patch("datachain.studio.RECONNECT_MAX_ATTEMPTS", 0)
@@ -1780,12 +1781,11 @@ def test_studio_job_logs_transient_handshake_failure_retries(
     capsys, mocker, studio_token
 ):
     from websockets.datastructures import Headers
+    from websockets.exceptions import InvalidStatus
     from websockets.http11 import Response
 
     def mock_connect(url, additional_headers):
-        raise websockets.exceptions.InvalidStatus(
-            Response(503, "Service Unavailable", Headers())
-        )
+        raise InvalidStatus(Response(503, "Service Unavailable", Headers()))
 
     mocker.patch("datachain.remote.studio.websockets.connect", side_effect=mock_connect)
     mocker.patch("datachain.studio.RECONNECT_MAX_ATTEMPTS", 0)
@@ -1814,14 +1814,13 @@ def test_studio_job_logs_terminal_error_on_reconnect_clears_banner(
     capsys, mocker, studio_token
 ):
     from websockets.datastructures import Headers
+    from websockets.exceptions import InvalidStatus
     from websockets.http11 import Response
 
     statuses = [503, 403]
 
     def mock_connect(url, additional_headers):
-        raise websockets.exceptions.InvalidStatus(
-            Response(statuses.pop(0), "", Headers())
-        )
+        raise InvalidStatus(Response(statuses.pop(0), "", Headers()))
 
     mocker.patch("datachain.remote.studio.websockets.connect", side_effect=mock_connect)
     mocker.patch("datachain.studio.RECONNECT_BACKOFF_BASE_SEC", 0)
@@ -1873,7 +1872,9 @@ def test_studio_job_logs_interrupt_during_backoff_clears_banner(
 def test_studio_job_logs_legacy_status_code_attribute_aborts(
     capsys, mocker, studio_token
 ):
-    class LegacyInvalidStatusCode(websockets.exceptions.WebSocketException):
+    from websockets.exceptions import WebSocketException
+
+    class LegacyInvalidStatusCode(WebSocketException):
         status_code = 403
 
     def mock_connect(url, additional_headers):


### PR DESCRIPTION
`datachain job logs <id>` against a team name the server does not accept printed nothing but a reconnect countdown and never said why — 15 attempts with backoff capped at 60s, so roughly ten minutes of silence before "Failed to reconnect". In practice you interrupt it first:

```
DATACHAIN_STUDIO_TEAM=wrong-team datachain job logs a23466fb-f11a-4fbd-82ef-35feca494faf
>>>> WebSocket closed, reconnecting in 8s...^CError: Operation cancelled by the user
```

Studio does report the problem over the log-streaming websocket. The client dropped it, in two independent places.

**Refused handshake.** For an unknown team, a team you cannot access, or an invalid token, Studio refuses the websocket handshake with HTTP 403. `websockets` raises a handshake exception, which `tail_job_logs` caught in a blanket `except (WebSocketException, OSError)` and turned into a `logger.debug` plus a bare `return` — indistinguishable from a normal end-of-stream.

**Error frame.** For a malformed job id, or a job you cannot access, Studio accepts the connection, sends `{"message": "Job ID is incorrect or not found"}`, and closes with code 4404. That frame was yielded into a branch chain in `show_logs_from_client` that only handles `log_blobs` / `logs` / `job`, so it fell through every branch and was discarded.

## What changed

- `tail_job_logs` raises `DataChainError` when a refused handshake carries 401 or 403, naming the team. Every other failure — a dropped connection, a 5xx from a gateway mid-deploy — still returns and lets the caller reconnect, so `job run` keeps its REST-polling fallback.
- `show_logs_from_client` raises the server's own message when it sees the terminal `{"message": ...}` frame.
- The reconnect banner is now cleared before each connection attempt instead of when the first message arrives, and also when the backoff sleep is interrupted. A terminal error or a Ctrl-C no longer prints on top of a stale `reconnecting in Ns...` countdown.
- Backoff moved into `_wait_before_reconnect`, next to the existing `_print_reconnect_msg` and `_clear_line` helpers. Behavior is identical — the sleep still uses the pre-increment retry count and the debug line still reports the same attempt number.

The error message names the team *and* the token as possible causes, because Studio deliberately answers the same way whether a team does not exist or you simply cannot reach it. The client cannot tell those apart and should not pretend to.

<sub>🤖 Co-authored by Claude Code and ChatGPT</sub>