### PR TITLE
fix: flatten models in tuples and nested mapping values as lists already are

### DIFF
--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator, Iterator
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -83,12 +83,66 @@ def flatten_list(obj_list: list[BaseModel]) -> tuple:
     )
 
 
-def _flatten_list_field(value: list) -> list:
-    assert isinstance(value, list)
-    if value and ModelStore.is_pydantic(type(value[0])):
-        return [val.model_dump() for val in value]
-    if value and isinstance(value[0], list):
-        return [_flatten_list_field(v) for v in value]
+_BARE_CONTAINERS = (dict, list, tuple, set, frozenset)
+
+
+def _may_hold_model(annotation: Any) -> bool:
+    """Whether a declared type can hold a model, erring towards yes when unsure.
+
+    An erased annotation -- Any, object, a bare container -- says nothing about
+    its contents, so it has to be walked.
+    """
+    if ModelStore.is_pydantic(annotation):
+        return True
+    if annotation is Any or annotation is object or annotation is None:
+        return True
+    args = get_args(annotation)
+    if not args:
+        return get_origin(annotation) is not None or annotation in _BARE_CONTAINERS
+    return any(arg is not Ellipsis and _may_hold_model(arg) for arg in args)
+
+
+def _flatten_sequence(value: Any, annotation: Any) -> Any:
+    args = get_args(annotation)
+    if (
+        get_origin(annotation) is tuple
+        and args
+        and args[-1] is not Ellipsis
+        and len(args) == len(value)
+    ):
+        if not any(_may_hold_model(arg) for arg in args):
+            return value
+        return [
+            _flatten_nested(item, arg) for item, arg in zip(value, args, strict=True)
+        ]
+    item_type = args[0] if args else Any
+    if not _may_hold_model(item_type):
+        return value
+    return [_flatten_nested(item, item_type) for item in value]
+
+
+def _flatten_mapping(value: dict, annotation: Any) -> Any:
+    args = get_args(annotation)
+    value_type = args[1] if len(args) == 2 else Any
+    if not _may_hold_model(value_type):
+        return value
+    return {key: _flatten_nested(item, value_type) for key, item in value.items()}
+
+
+def _flatten_nested(value: Any, annotation: Any) -> Any:
+    """Replace models with their JSON-mode dumps, leaving everything else alone.
+
+    JSON mode is what the warehouse applies to a model it receives directly, so
+    converting here keeps the two paths agreeing on dates, paths and serializers
+    declared for JSON output. A value whose declared type cannot hold a model is
+    returned as it is, so a vector of numbers is never copied.
+    """
+    if ModelStore.is_pydantic(type(value)):
+        return value.model_dump(mode="json")
+    if isinstance(value, (list, tuple)):
+        return _flatten_sequence(value, annotation)
+    if isinstance(value, dict):
+        return _flatten_mapping(value, annotation)
     return value
 
 
@@ -109,13 +163,8 @@ def _flatten_fields_values(fields: dict, obj: BaseModel) -> Generator[Any, None,
         kind = classify_field(f_info.annotation)
         # Direct attribute access skips Pydantic's model_dump().
         value = getattr(obj, name)
-        if isinstance(value, list):
-            yield _flatten_list_field(value)
-        elif isinstance(value, dict):
-            yield {
-                key: val.model_dump() if ModelStore.is_pydantic(type(val)) else val
-                for key, val in value.items()
-            }
+        if isinstance(value, (list, tuple, dict)):
+            yield _flatten_nested(value, f_info.annotation)
         elif kind.is_model:
             if kind.is_optional:
                 if value is None:

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -947,6 +947,55 @@ def test_map_hydrates_models_in_optional_dict_param(test_session):
     assert chain.to_values("count") == [3]
 
 
+class _Boxed(DataModel):
+    n: int
+
+
+@pytest.mark.parametrize(
+    "annotation,value,stored",
+    [
+        (list[_Boxed], [_Boxed(n=1)], [{"n": 1}]),
+        (tuple[_Boxed, ...], (_Boxed(n=1),), [{"n": 1}]),
+        (dict[str, list[_Boxed]], {"k": [_Boxed(n=1)]}, '{"k":[{"n":1}]}'),
+        (tuple[tuple[_Boxed, ...], ...], ((_Boxed(n=1),),), ['[{"n":1}]']),
+        (tuple[int, int], (1, 2), [1, 2]),
+    ],
+    ids=["list", "tuple", "dict-of-lists", "nested-tuples", "no-models"],
+)
+@skip_if_not_sqlite
+def test_save_writes_models_in_any_collection_as_objects(
+    test_session, annotation, value, stored
+):
+    holder = type("Holder", (DataModel,), {"__annotations__": {"field": annotation}})
+    saved = dc.read_values(c=[holder(field=value)], session=test_session).save("boxed")
+
+    warehouse = test_session.catalog.warehouse
+    table = warehouse.dataset_rows(
+        test_session.catalog.get_dataset("boxed", versions=["1.0.0"])
+    )
+    (row,) = warehouse.db.execute(table.select(table.c("field", "c")))
+
+    assert row[0] == stored
+    assert saved.to_values("c.field")[0] == value
+
+
+def test_read_keeps_working_for_a_tuple_written_before_the_format_changed(test_session):
+    class Holder(DataModel):
+        field: tuple[_Boxed, ...]
+
+    saved = dc.read_values(c=[Holder(field=(_Boxed(n=1),))], session=test_session).save(
+        "legacy"
+    )
+
+    warehouse = test_session.catalog.warehouse
+    table = warehouse.dataset_rows(
+        test_session.catalog.get_dataset("legacy", versions=["1.0.0"])
+    )
+    warehouse.db.execute(table.update().values({"c__field": '["{\\"n\\":1}"]'}))
+
+    assert saved.to_values("c.field")[0] == (_Boxed(n=1),)
+
+
 def test_map_hydrates_models_in_variadic_tuple_param(test_session):
     class TupleCollection(DataModel):
         items: tuple[MyFr, ...]

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -1580,6 +1580,49 @@ def test_signal_resolving_type_error_with_unpicklable_field():
     assert type(restored) is SignalResolvingTypeError
 
 
+class _FlatItem(BaseModel):
+    n: int
+
+
+@pytest.mark.parametrize(
+    "annotation,value,expected",
+    [
+        (list[_FlatItem], [_FlatItem(n=1)], [{"n": 1}]),
+        (tuple[_FlatItem, ...], (_FlatItem(n=1),), [{"n": 1}]),
+        (dict[str, list[_FlatItem]], {"k": [_FlatItem(n=1)]}, {"k": [{"n": 1}]}),
+        (dict[str, tuple[_FlatItem, ...]], {"k": (_FlatItem(n=1),)}, {"k": [{"n": 1}]}),
+        (list[list[_FlatItem]], [[_FlatItem(n=1)]], [[{"n": 1}]]),
+        (tuple[tuple[_FlatItem, ...], ...], ((_FlatItem(n=1),),), [[{"n": 1}]]),
+        (
+            dict[str, dict[str, _FlatItem]],
+            {"a": {"b": _FlatItem(n=1)}},
+            {"a": {"b": {"n": 1}}},
+        ),
+        (tuple[_FlatItem, int], (_FlatItem(n=1), 7), [{"n": 1}, 7]),
+        (tuple[int, _FlatItem], (7, _FlatItem(n=1)), [7, {"n": 1}]),
+        (tuple[int, int], (1, 2), (1, 2)),
+        (list[int], [1, 2], [1, 2]),
+    ],
+    ids=[
+        "list",
+        "tuple",
+        "dict-of-lists",
+        "dict-of-tuples",
+        "nested-lists",
+        "nested-tuples",
+        "nested-dicts",
+        "fixed-tuple-model-first",
+        "fixed-tuple-model-last",
+        "tuple-without-models-untouched",
+        "list-without-models-untouched",
+    ],
+)
+def test_flatten_converts_models_in_any_collection(annotation, value, expected):
+    holder = type("Holder", (BaseModel,), {"__annotations__": {"field": annotation}})
+
+    assert flatten(holder(field=value)) == (expected,)
+
+
 @pytest.mark.parametrize(
     "schema,hidden_fields",
     [


### PR DESCRIPTION
Models stored in a `tuple` are written double-encoded, unlike the same models in a `list`.

```python
class Box(dc.DataModel):
    label: str
    score: float

class Frame(dc.DataModel):
    boxes: tuple[Box, ...]

dc.read_values(frame=[Frame(boxes=(Box(label="cat", score=0.9),))]).save("frames")
```

What lands in the column:

```
before   ["{\"label\":\"cat\",\"score\":0.9}"]     a string holding JSON
after    [{"label":"cat","score":0.9}]             an object, same as list[Box]
```

## Why

`_flatten_fields_values` decided what to convert from the **runtime type** of the value and knew only `list` and `dict`. A tuple matched neither, so it was passed through with its `Box` objects intact and the warehouse serialized each one separately. The `dict` branch had the same gap one level down: it converted a value that *was* a model, but not one that was a list of them.

It now decides from the **declared type** instead, and converts elements one at a time.

## This changes the stored format

`tuple[Model, ...]` columns written before this will not compare equal to ones written after — `union`/`distinct`, `subtract` and `merge` between an old and a new dataset will disagree. Reads are unaffected: both spellings still load as the declared type, verified by writing on `main` and reading here.

That break is deliberate. The current spelling is a bug, the shape is rare — `tuple[Model, ...]` as a stored signal appears once in this repository and nowhere in `src/` or `examples/` — and leaving it costs a permanent gap in #1943 (below).

## Deciding from the annotation, not the value

Two things follow from that, both of which an earlier revision got wrong:

- A collection that **cannot** hold a model is never walked. `list[int]` and `tuple[int, int]` pass through untouched, so embedding vectors cost nothing to write and keep their identity for content hashing.
- Elements are converted **individually** rather than from whatever the first one happens to be. A fixed-length tuple needs this: `tuple[Item, int]` would otherwise call `model_dump()` on the `int`.

## Not fixed here

`tuple[int, Model]` is still written as an array of strings, byte-identical to `main`. The warehouse chooses the array conversion from the first element, so a leading non-model sends the whole array down the per-element path. Independent of this change.

## Side effect

This closes the two shapes #1943 carries a strict `xfail` for. A `dict` arriving inside a live model has already been through `model_dump`, which merges keys that serialize to the same JSON name; the same `dict` inside a list arrives intact. Flattening them alike lets the existing check see both keys, with no new code there.
