### PR TITLE
feat: serialize pathlib paths like the other extra types

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -7,6 +7,7 @@ import string
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
+from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Union, cast
 from urllib.parse import urlparse
 
@@ -106,6 +107,13 @@ class AbstractWarehouse(ABC, Serializable):
         if isinstance(obj, dict):
             out: dict[str, Any] = {}
             for k, v in obj.items():
+                if isinstance(k, PurePath):
+                    # Written as its JSON text, quotes and all, and nothing on
+                    # the read side turns that back into a path.
+                    raise TypeError(
+                        f"Cannot use {type(k).__name__} as a mapping key: "
+                        "paths are not supported as JSON object names"
+                    )
                 if not isinstance(k, str):
                     key_str = json.dumps(
                         self._to_jsonable(k),

--- a/src/datachain/json.py
+++ b/src/datachain/json.py
@@ -9,6 +9,7 @@ All code inside DataChain should import this module instead of using
 
 import datetime as _dt
 import json as _json
+import pathlib as _pathlib
 import sys as _sys
 import uuid as _uuid
 from collections.abc import Callable
@@ -69,7 +70,7 @@ def _coerce(value: Any, serialize_bytes: bool, serialize_numpy: bool) -> Any:
         converted = value.isoformat()
     elif isinstance(value, _dt.time):
         converted = _format_time(value)
-    elif isinstance(value, _uuid.UUID):
+    elif isinstance(value, (_uuid.UUID, _pathlib.PurePath)):
         converted = str(value)
 
     if converted is _SENTINEL and serialize_numpy:

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import io
+import pathlib
 import sys
 
 import numpy as np
@@ -69,6 +70,48 @@ def test_datetime_serialization_matches_pydantic_json_mode() -> None:
         )
         == expected
     )
+
+
+class PathPayload(BaseModel):
+    pure: pathlib.PurePosixPath
+    relative: pathlib.PurePath
+    concrete: pathlib.Path
+
+
+def test_path_serialization_matches_pydantic_json_mode() -> None:
+    payload = PathPayload(
+        pure=pathlib.PurePosixPath("/a/b"),
+        relative=pathlib.PurePath("rel/name.txt"),
+        concrete=pathlib.Path("/a/b"),
+    )
+
+    assert json.loads(
+        json.dumps(
+            {
+                "pure": payload.pure,
+                "relative": payload.relative,
+                "concrete": payload.concrete,
+            }
+        )
+    ) == payload.model_dump(mode="json")
+
+
+@pytest.mark.parametrize("serialize_bytes", [False, True])
+def test_path_serialization_works_in_both_encoders(serialize_bytes: bool) -> None:
+    value = {"p": pathlib.PurePosixPath("/a/b")}
+
+    assert json.loads(json.dumps(value, serialize_bytes=serialize_bytes)) == {
+        "p": "/a/b"
+    }
+
+
+def test_path_serialization_handles_nested_values() -> None:
+    value = {
+        "a": [pathlib.PurePosixPath("/x")],
+        "b": {"c": pathlib.PurePosixPath("/y")},
+    }
+
+    assert json.loads(json.dumps(value)) == {"a": ["/x"], "b": {"c": "/y"}}
 
 
 def test_numpy_serialization_is_opt_in() -> None:

--- a/tests/unit/test_warehouse.py
+++ b/tests/unit/test_warehouse.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import pathlib
 from unittest.mock import patch
 
 import pytest
@@ -9,6 +10,23 @@ import datachain as dc
 from datachain.data_storage.serializer import deserialize
 from datachain.data_storage.sqlite import SQLiteWarehouse
 from datachain.lib.file import File
+from datachain.sql.types import JSON
+
+
+def test_to_jsonable_refuses_a_path_mapping_key(warehouse):
+    with pytest.raises(TypeError, match="paths are not supported"):
+        warehouse.convert_type(
+            {pathlib.PurePosixPath("/a"): 1}, JSON(), dict, "JSON", "c"
+        )
+
+
+def test_to_jsonable_keeps_a_path_value(warehouse):
+    assert (
+        warehouse.convert_type(
+            {"p": pathlib.PurePosixPath("/a")}, JSON(), dict, "JSON", "c"
+        )
+        == '{"p":"\\/a"}'
+    )
 
 
 def test_serialize(sqlite_db):


### PR DESCRIPTION
A model field declared as a `Path` cannot be stored:

```python
class Doc(dc.DataModel):
    source: pathlib.PurePosixPath

class Batch(dc.DataModel):
    docs: list[Doc]

dc.read_values(b=[Batch(docs=[Doc(source=pathlib.PurePosixPath("/data/a.txt"))])]).save("b")
# TypeError: Object of type PurePosixPath is not JSON serializable
```

`datachain.json` exists to teach ujson the types it does not handle on its own — `datetime`, `date`, `time`, `UUID`, numpy arrays, `bytes`. Paths were missing, so a value that reaches the encoder still holding its Python type has nowhere to go.

That happens for a list of models, whose fields are dumped in Pydantic's *python* mode and therefore keep their Python types. The same model reached another way is converted by Pydantic first and stores fine, which is why this shows up in one shape and not another.

Paths are written with `str()`, which is what Pydantic's JSON mode produces for `PurePath`, `PurePosixPath` and `Path` alike, so a value written either way reads back identically. The test asserts that equivalence against `model_dump(mode="json")` rather than hard-coding a string.

## Scope: values, not keys

Teaching the encoder about paths made one shape reachable that `main` rejected, and it stored badly — the key became its JSON text, quotes and all, the two read routes disagreed, and an equality filter matched nothing. So a path used as a mapping key is refused explicitly where `_to_jsonable` builds the mapping, keeping `main`'s behaviour:

```
TypeError: Cannot use PurePosixPath as a mapping key: paths are not
supported as JSON object names
```

This covers a path key wherever `_to_jsonable` builds the mapping, which is every JSON column on both backends. It does not reach array items, whose handling already differs by backend for reasons unrelated to paths — that is untouched here.

Making rich mapping keys work — paths, datetimes, UUIDs — needs read-side reconstruction and filter normalisation, and none of them work today. That belongs with the read-path work in #1918.

Both encoder branches are covered: `ujson` silently coerces a path key while stdlib rejects it, so the tests assert path *values* work under `serialize_bytes` either way.
