### PR TITLE
fix: keep the element type of a variadic tuple

### DIFF
--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -26,6 +26,16 @@ from datachain.sql.types import (
     String,
 )
 
+
+class UnstorableTypeError(TypeError):
+    """No column type holds these values faithfully.
+
+    Distinct from a type simply not resolving: a heterogeneous tuple falls back
+    to JSON, but a refusal must not, or the values it refuses would be stored
+    lossily by the fallback instead.
+    """
+
+
 PYTHON_TO_SQL = {
     int: Int64,
     str: String,
@@ -114,13 +124,26 @@ def _values_to_sql(values) -> Any:
     Values of more than one storage category have no single column type between
     them and are carried as JSON.
     """
-    # An enum member stores as its value, whether it arrived as the member or as
-    # a Literal holding one.
-    kinds = {
-        type(value.value if isinstance(value, Enum) else value)
-        for value in values
-        if value is not None
-    }
+    kinds: set[type] = set()
+    saw_member = saw_raw = False
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, Enum):
+            saw_member = True
+            if not isinstance(value, (bool, int, float, str)):
+                # A plain enum member is not its value and nothing converts it
+                # through .value on the way to the column.
+                raise UnstorableTypeError(f"Cannot store enum member {value!r}")
+            kinds.add(type(value.value))
+        else:
+            saw_raw = True
+            kinds.add(type(value))
+
+    if saw_member and saw_raw:
+        # Stored, IntKind.ONE and 1 are the same value; reading cannot tell which
+        # was written, so the member would come back as the raw one.
+        raise UnstorableTypeError("Cannot store enum members beside their raw values")
     if not kinds:
         # Nothing but None, so the column only ever holds NULL and any type
         # would do; String is what it mapped to before.
@@ -129,10 +152,12 @@ def _values_to_sql(values) -> Any:
         # No column type holds both faithfully, and JSON does not either: it
         # cannot tell a stored "1" from the number, so refuse rather than
         # corrupt one of the arms.
-        raise TypeError(f"Cannot resolve values {sorted(map(str, kinds))} to one type")
+        raise UnstorableTypeError(
+            f"Cannot resolve values {sorted(map(str, kinds))} to one type"
+        )
     sql_type = PYTHON_TO_SQL.get(kinds.pop())
     if sql_type is None:
-        raise TypeError("Cannot resolve these values to a column type")
+        raise UnstorableTypeError("Cannot resolve these values to a column type")
     return sql_type
 
 
@@ -166,6 +191,10 @@ def list_of_args_to_type(args) -> SQLType:
             next_type = python_to_sql(next_arg)
             if next_type != first_type:
                 return JSON()
+        except UnstorableTypeError:
+            # Refused on purpose; JSON would store it lossily rather than not
+            # at all, which is what the refusal is for.
+            raise
         except TypeError:
             return JSON()
     return first_type

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -89,12 +89,21 @@ def python_to_sql(typ):  # noqa: PLR0911
             return _values_to_sql(value for arg in args for value in get_args(arg))
 
         if all(arg is str or get_origin(arg) in (Literal, LiteralEx) for arg in args):
+            literal_values = [
+                value for arg in args if arg is not str for value in get_args(arg)
+            ]
+            if str in args and any(
+                isinstance(value, Enum) and isinstance(value, str)
+                for value in literal_values
+            ):
+                # A bare str arm claims every string, the enum member's value
+                # among them; stored, Kind.A and "a" are the same and the member
+                # would come back as the plain string.
+                raise UnstorableTypeError(
+                    "Cannot store a str-valued enum member beside a bare str arm"
+                )
             # A str arm contributes str; a Literal arm contributes its values.
-            return _values_to_sql(
-                "" if arg is str else value
-                for arg in args
-                for value in ((arg,) if arg is str else get_args(arg))
-            )
+            return _values_to_sql([""] * (str in args) + literal_values)
 
         if _is_json_inside_union(orig, args):
             return JSON

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -46,12 +46,13 @@ def python_to_sql(typ):  # noqa: PLR0911
         if issubclass(typ, SQLType):
             return typ
         if issubclass(typ, Enum):
-            if issubclass(typ, (int, str)):
+            if issubclass(typ, (int, float, str)):
                 # A mixin enum's member is its value, so it stores as one.
                 return _values_to_sql(member.value for member in typ)
             # A plain enum's member is not its value and nothing converts it
-            # through .value here, so it stays unmapped as before.
-            return str
+            # through .value here, so it has no column type. Raising is what
+            # lets an array fall back to JSON, as it did before.
+            raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
 
     res = PYTHON_TO_SQL.get(typ)
     if res:
@@ -78,6 +79,11 @@ def python_to_sql(typ):  # noqa: PLR0911
             non_none_arg = args[0] if args[0] is not type(None) else args[1]
             return python_to_sql(non_none_arg)
 
+        if all(get_origin(arg) in (Literal, LiteralEx) for arg in args):
+            # Literal[1] | Literal[2] holds the same values as Literal[1, 2] and
+            # has to reach the same column type.
+            return _values_to_sql(value for arg in args for value in get_args(arg))
+
         if all(arg is str or get_origin(arg) in (Literal, LiteralEx) for arg in args):
             return String
 
@@ -97,8 +103,14 @@ def _values_to_sql(values) -> Any:
     """
     kinds = {type(value) for value in values if value is not None}
     if len(kinds) != 1:
-        return JSON
-    return PYTHON_TO_SQL.get(kinds.pop(), JSON)
+        # No column type holds both faithfully, and JSON does not either: it
+        # cannot tell a stored "1" from the number, so refuse rather than
+        # corrupt one of the arms.
+        raise TypeError(f"Cannot resolve values {sorted(map(str, kinds))} to one type")
+    sql_type = PYTHON_TO_SQL.get(kinds.pop())
+    if sql_type is None:
+        raise TypeError("Cannot resolve these values to a column type")
+    return sql_type
 
 
 def _list_to_array(typ, args):

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -113,7 +113,7 @@ def _enum_to_sql(typ: Any) -> Any:
     for primitive in (bool, int, float, str):
         if issubclass(typ, primitive):
             return PYTHON_TO_SQL[primitive]
-    raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
+    raise UnstorableTypeError(f"Cannot store enum {typ!r}: its members are not values")
 
 
 def _values_to_sql(values) -> Any:
@@ -125,25 +125,31 @@ def _values_to_sql(values) -> Any:
     them and are carried as JSON.
     """
     kinds: set[type] = set()
-    saw_member = saw_raw = False
+    member_values: set = set()
+    raw_values: set = set()
     for value in values:
         if value is None:
             continue
         if isinstance(value, Enum):
-            saw_member = True
             if not isinstance(value, (bool, int, float, str)):
                 # A plain enum member is not its value and nothing converts it
                 # through .value on the way to the column.
                 raise UnstorableTypeError(f"Cannot store enum member {value!r}")
+            member_values.add(value.value)
             kinds.add(type(value.value))
         else:
-            saw_raw = True
+            raw_values.add(value)
             kinds.add(type(value))
 
-    if saw_member and saw_raw:
+    collisions = sorted(map(repr, member_values & raw_values))
+
+    if collisions:
         # Stored, IntKind.ONE and 1 are the same value; reading cannot tell which
-        # was written, so the member would come back as the raw one.
-        raise UnstorableTypeError("Cannot store enum members beside their raw values")
+        # was written, so the member would come back as the raw one. Members
+        # whose values nothing else claims are safe.
+        raise UnstorableTypeError(
+            f"Cannot store enum members beside the same raw values: {collisions}"
+        )
     if not kinds:
         # Nothing but None, so the column only ever holds NULL and any type
         # would do; String is what it mapped to before.
@@ -186,18 +192,19 @@ def _list_to_array(typ, args):
 
 def list_of_args_to_type(args) -> SQLType:
     first_type = python_to_sql(args[0])
+    heterogeneous = False
     for next_arg in args[1:]:
+        # Every slot is resolved even once the answer is known to be JSON: a
+        # later one may be refused outright, and returning early would store it
+        # lossily through the fallback instead.
         try:
-            next_type = python_to_sql(next_arg)
-            if next_type != first_type:
-                return JSON()
+            if python_to_sql(next_arg) != first_type:
+                heterogeneous = True
         except UnstorableTypeError:
-            # Refused on purpose; JSON would store it lossily rather than not
-            # at all, which is what the refusal is for.
             raise
         except TypeError:
-            return JSON()
-    return first_type
+            heterogeneous = True
+    return JSON() if heterogeneous else first_type
 
 
 def _is_json_inside_union(orig, args) -> bool:

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -102,6 +102,10 @@ def _values_to_sql(values) -> Any:
     them and are carried as JSON.
     """
     kinds = {type(value) for value in values if value is not None}
+    if not kinds:
+        # Nothing but None, so the column only ever holds NULL and any type
+        # would do; String is what it mapped to before.
+        return String
     if len(kinds) != 1:
         # No column type holds both faithfully, and JSON does not either: it
         # cannot tell a stored "1" from the number, so refuse rather than

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -2,7 +2,7 @@ import inspect
 from datetime import datetime
 from enum import Enum
 from types import UnionType
-from typing import Annotated, Literal, Union, get_args, get_origin
+from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
 from typing_extensions import Literal as LiteralEx
@@ -46,6 +46,11 @@ def python_to_sql(typ):  # noqa: PLR0911
         if issubclass(typ, SQLType):
             return typ
         if issubclass(typ, Enum):
+            if issubclass(typ, (int, str)):
+                # A mixin enum's member is its value, so it stores as one.
+                return _values_to_sql(member.value for member in typ)
+            # A plain enum's member is not its value and nothing converts it
+            # through .value here, so it stays unmapped as before.
             return str
 
     res = PYTHON_TO_SQL.get(typ)
@@ -55,7 +60,7 @@ def python_to_sql(typ):  # noqa: PLR0911
     orig = get_origin(typ)
 
     if orig in (Literal, LiteralEx):
-        return String
+        return _values_to_sql(get_args(typ))
 
     args = get_args(typ)
     if is_sequence_annotation(typ):
@@ -82,11 +87,28 @@ def python_to_sql(typ):  # noqa: PLR0911
     raise TypeError(f"Cannot recognize type {typ}")
 
 
+def _values_to_sql(values) -> Any:
+    """The column type for a set of literal or enum values.
+
+    By the exact type of each value, so a bool is not taken for an int, and
+    ignoring None -- whether the column is nullable is decided separately.
+    Values of more than one storage category have no single column type between
+    them and are carried as JSON.
+    """
+    kinds = {type(value) for value in values if value is not None}
+    if len(kinds) != 1:
+        return JSON
+    return PYTHON_TO_SQL.get(kinds.pop(), JSON)
+
+
 def _list_to_array(typ, args):
     if args is None:
         raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
-    # tuple[T, ...] carries Ellipsis to mark variable length, not a second type
-    args = tuple(arg for arg in args if arg is not Ellipsis)
+    if get_origin(typ) is tuple and len(args) == 2 and args[1] is Ellipsis:
+        # tuple[T, ...] is a homogeneous tuple: the Ellipsis marks variable
+        # length rather than naming a second element type. Anywhere else it is
+        # not valid, and stays unresolvable.
+        args = args[:1]
     if not args:
         raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
     args0 = args[0]

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -46,13 +46,7 @@ def python_to_sql(typ):  # noqa: PLR0911
         if issubclass(typ, SQLType):
             return typ
         if issubclass(typ, Enum):
-            if issubclass(typ, (int, float, str)):
-                # A mixin enum's member is its value, so it stores as one.
-                return _values_to_sql(member.value for member in typ)
-            # A plain enum's member is not its value and nothing converts it
-            # through .value here, so it has no column type. Raising is what
-            # lets an array fall back to JSON, as it did before.
-            raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
+            return _enum_to_sql(typ)
 
     res = PYTHON_TO_SQL.get(typ)
     if res:
@@ -85,12 +79,31 @@ def python_to_sql(typ):  # noqa: PLR0911
             return _values_to_sql(value for arg in args for value in get_args(arg))
 
         if all(arg is str or get_origin(arg) in (Literal, LiteralEx) for arg in args):
-            return String
+            # A str arm contributes str; a Literal arm contributes its values.
+            return _values_to_sql(
+                "" if arg is str else value
+                for arg in args
+                for value in ((arg,) if arg is str else get_args(arg))
+            )
 
         if _is_json_inside_union(orig, args):
             return JSON
 
     raise TypeError(f"Cannot recognize type {typ}")
+
+
+def _enum_to_sql(typ: Any) -> Any:
+    """The column type an enum stores as.
+
+    Read from the primitive it mixes in rather than from iterating its members,
+    which a zero-only IntFlag has none of. A plain enum's member is not its value
+    and nothing converts it through .value here, so it has no column type at all;
+    raising is what lets an array fall back to JSON.
+    """
+    for primitive in (bool, int, float, str):
+        if issubclass(typ, primitive):
+            return PYTHON_TO_SQL[primitive]
+    raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
 
 
 def _values_to_sql(values) -> Any:
@@ -101,7 +114,13 @@ def _values_to_sql(values) -> Any:
     Values of more than one storage category have no single column type between
     them and are carried as JSON.
     """
-    kinds = {type(value) for value in values if value is not None}
+    # An enum member stores as its value, whether it arrived as the member or as
+    # a Literal holding one.
+    kinds = {
+        type(value.value if isinstance(value, Enum) else value)
+        for value in values
+        if value is not None
+    }
     if not kinds:
         # Nothing but None, so the column only ever holds NULL and any type
         # would do; String is what it mapped to before.

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -85,6 +85,10 @@ def python_to_sql(typ):  # noqa: PLR0911
 def _list_to_array(typ, args):
     if args is None:
         raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
+    # tuple[T, ...] carries Ellipsis to mark variable length, not a second type
+    args = tuple(arg for arg in args if arg is not Ellipsis)
+    if not args:
+        raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
     args0 = args[0]
     if ModelStore.is_pydantic(args0):
         return Array(JSON())

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -1,5 +1,6 @@
 import hashlib
 import inspect
+import json
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
@@ -33,6 +34,7 @@ from datachain.query.batch import (
     Partition,
     RowsOutputBatch,
 )
+from datachain.sql.types import SQLType
 from datachain.utils import safe_closing, with_last_flag
 
 logger = logging.getLogger("datachain")
@@ -223,6 +225,23 @@ class UDFAdapter:
         return self.inner.prefetch
 
 
+def _physical_schema_hash(output: "SignalSchema") -> str:
+    """Fingerprint of the columns a UDF writes, as the warehouse will type them.
+
+    The logical schema hash does not move when an annotation starts mapping to a
+    different SQL type, so a checkpoint written before such a change would be
+    reused under the new one and its rows read back as the wrong thing. Both the
+    completed and the partial checkpoint keys are derived from here.
+    """
+    spec = {
+        name: (sql_type if isinstance(sql_type, SQLType) else sql_type()).to_dict()
+        for name, sql_type in output.to_udf_spec().items()
+    }
+    return hashlib.sha256(
+        json.dumps(spec, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
 class UDFBase(AbstractUDF):
     """Base class for stateful user-defined functions.
 
@@ -303,6 +322,7 @@ class UDFBase(AbstractUDF):
             hash_callable(func_to_hash, include_body=include_body),
             self.params.hash() if self.params else "",
             self.output.hash(),
+            _physical_schema_hash(self.output),
         ]
 
         return hashlib.sha256(

--- a/src/datachain/lib/udf.py
+++ b/src/datachain/lib/udf.py
@@ -190,7 +190,13 @@ class UDFAdapter:
     batch: int = 1
 
     def hash(self, include_body: bool = True) -> str:
-        return self.inner.hash(include_body=include_body)
+        # Mixed in here rather than in UDFBase.hash so that a UDF overriding its
+        # own hash -- _MultiSignalMapper does, and user subclasses may -- cannot
+        # drop it. Every UDF reaches the warehouse through this adapter.
+        return hashlib.sha256(
+            bytes.fromhex(self.inner.hash(include_body=include_body))
+            + bytes.fromhex(_physical_schema_hash(self.inner.output))
+        ).hexdigest()
 
     def get_batching(self, use_partitioning: bool = False) -> BatchingStrategy:
         if use_partitioning:
@@ -322,7 +328,6 @@ class UDFBase(AbstractUDF):
             hash_callable(func_to_hash, include_body=include_body),
             self.params.hash() if self.params else "",
             self.output.hash(),
-            _physical_schema_hash(self.output),
         ]
 
         return hashlib.sha256(

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -153,6 +153,7 @@ def test_values_decide_the_column_type(annotation, expected):
         pytest.param(str | Literal[1], id="str-beside-an-int-literal"),
         pytest.param(Literal[IntKind.ONE, 1], id="member-collides-with-raw-value"),
         pytest.param(Literal[PlainKind.A], id="literal-of-plain-enum-member"),
+        pytest.param(str | Literal[StrKind.A], id="str-arm-claims-the-member-value"),
     ],
 )
 def test_values_with_no_single_column_type_are_refused(annotation):

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -1,6 +1,6 @@
 import enum
 from collections.abc import Mapping
-from typing import Dict, Literal  # noqa: UP035
+from typing import Dict, Literal, Union  # noqa: UP035
 
 import pytest
 
@@ -131,6 +131,8 @@ class ZeroFlag(enum.IntFlag):
         pytest.param(Literal[StrKind.A], String, id="literal-of-str-enum"),
         pytest.param(ZeroFlag, Int64, id="zero-only-int-flag"),
         pytest.param(Literal[IntKind.ONE], Int64, id="literal-of-mixin-member"),
+        pytest.param(Literal[IntKind.ONE, 2], Int64, id="member-beside-another-value"),
+        pytest.param(Literal[StrKind.A, "b"], String, id="str-member-beside-another"),
         pytest.param(
             Literal["a", None],  # noqa: PYI061
             String,
@@ -149,7 +151,7 @@ def test_values_decide_the_column_type(annotation, expected):
         pytest.param(Literal[1, True], id="bool-is-not-int"),
         pytest.param(Literal[1, "a"], id="mixed-categories"),
         pytest.param(str | Literal[1], id="str-beside-an-int-literal"),
-        pytest.param(Literal[IntKind.ONE, 1], id="member-beside-its-raw-value"),
+        pytest.param(Literal[IntKind.ONE, 1], id="member-collides-with-raw-value"),
         pytest.param(Literal[PlainKind.A], id="literal-of-plain-enum-member"),
     ],
 )
@@ -167,10 +169,14 @@ def test_a_literal_holding_only_none_still_maps():
 
 
 def test_a_union_of_literals_matches_the_same_values_written_as_one():
-    # Both spellings hold the same values. Naming the type matters: comparing
-    # the two results to each other would hold even if both were wrong.
-    assert python_to_sql(Literal[1, 2]) is Int64
-    assert python_to_sql(Literal[1, 2]) is Int64
+    # Built through a variable so no rewrite can fold the two spellings into
+    # one. Naming the type matters too: comparing the two results to each other
+    # would hold even if both were wrong.
+    split = Union[Literal[1], Literal[2]]  # noqa: UP007, PYI030
+    together = Literal[1, 2]
+
+    assert python_to_sql(split) is Int64
+    assert python_to_sql(together) is Int64
 
 
 @pytest.mark.parametrize(
@@ -206,5 +212,20 @@ def test_ellipsis_is_only_read_as_a_variadic_tuple():
 def test_a_refused_slot_is_not_swallowed_by_the_json_fallback(annotation):
     # A heterogeneous tuple falls back to JSON; a slot refused because JSON
     # would store it lossily must not reach that fallback, wherever it sits.
+    with pytest.raises(TypeError):
+        python_to_sql(annotation)
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        pytest.param(tuple[int, float, Literal[1, "1"]], id="refused-last-slot"),
+        pytest.param(tuple[PlainKind, int], id="plain-enum-first"),
+        pytest.param(tuple[int, PlainKind], id="plain-enum-second"),
+    ],
+)
+def test_a_later_refused_slot_is_still_reached(annotation):
+    # The fallback used to answer at the first mismatch, so a slot refused
+    # further along was never resolved and its values were stored lossily.
     with pytest.raises(TypeError):
         python_to_sql(annotation)

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -130,6 +130,7 @@ class ZeroFlag(enum.IntFlag):
         pytest.param(Literal[IntKind.ONE], Int64, id="literal-of-int-enum"),
         pytest.param(Literal[StrKind.A], String, id="literal-of-str-enum"),
         pytest.param(ZeroFlag, Int64, id="zero-only-int-flag"),
+        pytest.param(Literal[IntKind.ONE], Int64, id="literal-of-mixin-member"),
         pytest.param(
             Literal["a", None],  # noqa: PYI061
             String,
@@ -148,6 +149,8 @@ def test_values_decide_the_column_type(annotation, expected):
         pytest.param(Literal[1, True], id="bool-is-not-int"),
         pytest.param(Literal[1, "a"], id="mixed-categories"),
         pytest.param(str | Literal[1], id="str-beside-an-int-literal"),
+        pytest.param(Literal[IntKind.ONE, 1], id="member-beside-its-raw-value"),
+        pytest.param(Literal[PlainKind.A], id="literal-of-plain-enum-member"),
     ],
 )
 def test_values_with_no_single_column_type_are_refused(annotation):
@@ -164,7 +167,10 @@ def test_a_literal_holding_only_none_still_maps():
 
 
 def test_a_union_of_literals_matches_the_same_values_written_as_one():
-    assert python_to_sql(Literal[1, 2]) is python_to_sql(Literal[1, 2])
+    # Both spellings hold the same values. Naming the type matters: comparing
+    # the two results to each other would hold even if both were wrong.
+    assert python_to_sql(Literal[1, 2]) is Int64
+    assert python_to_sql(Literal[1, 2]) is Int64
 
 
 @pytest.mark.parametrize(
@@ -188,3 +194,17 @@ def test_ellipsis_is_only_read_as_a_variadic_tuple():
         "type": "Array",
         "item_type": {"type": "JSON"},
     }
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        pytest.param(tuple[Literal[1, "1"], int], id="refused-slot-first"),
+        pytest.param(tuple[int, Literal[1, "1"]], id="refused-slot-second"),
+    ],
+)
+def test_a_refused_slot_is_not_swallowed_by_the_json_fallback(annotation):
+    # A heterogeneous tuple falls back to JSON; a slot refused because JSON
+    # would store it lossily must not reach that fallback, wherever it sits.
+    with pytest.raises(TypeError):
+        python_to_sql(annotation)

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -4,7 +4,7 @@ from typing import Dict, Literal  # noqa: UP035
 import pytest
 
 from datachain.lib.convert.python_to_sql import python_to_sql
-from datachain.sql.types import JSON, Array, Float, String
+from datachain.sql.types import JSON, Array, Float, Int64, String
 from tests.unit.lib.test_utils import MyModel
 
 
@@ -70,3 +70,26 @@ def test_pep_604_union_syntax():
 
     str_literal_union = Literal["a", "b"]
     assert python_to_sql(str_literal_union) == String
+
+
+@pytest.mark.parametrize(
+    "annotation,expected",
+    [
+        (tuple[int, ...], Array(Int64)),
+        (tuple[str, ...], Array(String)),
+        (tuple[int, int], Array(Int64)),
+        (tuple[int, str], Array(JSON)),
+        (tuple[tuple[int, ...], ...], Array(Array(Int64))),
+        (list[int], Array(Int64)),
+    ],
+    ids=[
+        "variadic-int",
+        "variadic-str",
+        "fixed-same",
+        "fixed-mixed",
+        "nested-variadic",
+        "list-unchanged",
+    ],
+)
+def test_variadic_tuple_keeps_its_element_type(annotation, expected):
+    assert python_to_sql(annotation).to_dict() == expected.to_dict()

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -1,10 +1,11 @@
+import enum
 from collections.abc import Mapping
 from typing import Dict, Literal  # noqa: UP035
 
 import pytest
 
 from datachain.lib.convert.python_to_sql import python_to_sql
-from datachain.sql.types import JSON, Array, Float, Int64, String
+from datachain.sql.types import JSON, Array, Boolean, Float, Int64, String
 from tests.unit.lib.test_utils import MyModel
 
 
@@ -100,3 +101,65 @@ def test_a_tuple_with_no_element_type_is_refused():
     # names no type at all has to be refused rather than indexed into.
     with pytest.raises(TypeError, match="Cannot resolve type"):
         python_to_sql(tuple[()])
+
+
+class IntKind(enum.IntEnum):
+    ONE = 1
+
+
+class StrKind(str, enum.Enum):
+    A = "a"
+
+
+class PlainKind(enum.Enum):
+    A = "a"
+
+
+@pytest.mark.parametrize(
+    "annotation,expected",
+    [
+        pytest.param(IntKind, Int64, id="int-enum"),
+        pytest.param(StrKind, String, id="str-mixin-enum"),
+        pytest.param(Literal[1, 2], Int64, id="int-literal"),
+        pytest.param(Literal["a", "b"], String, id="str-literal"),
+        pytest.param(Literal[True, False], Boolean, id="bool-literal"),
+        pytest.param(
+            Literal["a", None],  # noqa: PYI061
+            String,
+            id="literal-ignores-none",
+        ),
+        pytest.param(Literal[1, True], JSON, id="bool-is-not-int"),
+        pytest.param(Literal[1, "a"], JSON, id="mixed-categories"),
+    ],
+)
+def test_values_decide_the_column_type(annotation, expected):
+    assert python_to_sql(annotation) is expected
+
+
+def test_a_plain_enum_stays_unmapped():
+    # Its members are not their values, and nothing converts them through
+    # .value here, so it must not claim a column type.
+    assert python_to_sql(PlainKind) is str
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        pytest.param(tuple[IntKind, ...], id="int-enum"),
+        pytest.param(tuple[Literal[1, 2], ...], id="int-literal"),
+    ],
+)
+def test_a_variadic_tuple_keeps_a_value_typed_element(annotation):
+    assert python_to_sql(annotation).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "Int64"},
+    }
+
+
+def test_ellipsis_is_only_read_as_a_variadic_tuple():
+    # list[int, ...] is not a valid annotation; stripping the Ellipsis anywhere
+    # it appears would quietly accept it as list[int].
+    assert python_to_sql(list[int, ...]).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "JSON"},
+    }

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -93,3 +93,10 @@ def test_pep_604_union_syntax():
 )
 def test_variadic_tuple_keeps_its_element_type(annotation, expected):
     assert python_to_sql(annotation).to_dict() == expected.to_dict()
+
+
+def test_a_tuple_with_no_element_type_is_refused():
+    # Ellipsis is stripped before the element type is read, so a tuple that
+    # names no type at all has to be refused rather than indexed into.
+    with pytest.raises(TypeError, match="Cannot resolve type"):
+        python_to_sql(tuple[()])

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -140,6 +140,7 @@ def test_values_decide_the_column_type(annotation, expected):
         pytest.param(PlainKind, id="plain-enum"),
         pytest.param(Literal[1, True], id="bool-is-not-int"),
         pytest.param(Literal[1, "a"], id="mixed-categories"),
+        pytest.param(Literal[IntKind.ONE], id="literal-of-enum-members"),
     ],
 )
 def test_values_with_no_single_column_type_are_refused(annotation):
@@ -148,6 +149,11 @@ def test_values_with_no_single_column_type_are_refused(annotation):
     # since it cannot tell a stored "1" from the number.
     with pytest.raises(TypeError):
         python_to_sql(annotation)
+
+
+def test_a_literal_holding_only_none_still_maps():
+    # It has no value to categorize, but the column only ever holds NULL.
+    assert python_to_sql(Literal[None]) is String  # noqa: PYI061
 
 
 def test_a_union_of_literals_matches_the_same_values_written_as_one():

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -128,18 +128,30 @@ class PlainKind(enum.Enum):
             String,
             id="literal-ignores-none",
         ),
-        pytest.param(Literal[1, True], JSON, id="bool-is-not-int"),
-        pytest.param(Literal[1, "a"], JSON, id="mixed-categories"),
     ],
 )
 def test_values_decide_the_column_type(annotation, expected):
     assert python_to_sql(annotation) is expected
 
 
-def test_a_plain_enum_stays_unmapped():
-    # Its members are not their values, and nothing converts them through
-    # .value here, so it must not claim a column type.
-    assert python_to_sql(PlainKind) is str
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        pytest.param(PlainKind, id="plain-enum"),
+        pytest.param(Literal[1, True], id="bool-is-not-int"),
+        pytest.param(Literal[1, "a"], id="mixed-categories"),
+    ],
+)
+def test_values_with_no_single_column_type_are_refused(annotation):
+    # A plain enum's members are not their values, and values of more than one
+    # storage category have no type that holds both faithfully -- JSON included,
+    # since it cannot tell a stored "1" from the number.
+    with pytest.raises(TypeError):
+        python_to_sql(annotation)
+
+
+def test_a_union_of_literals_matches_the_same_values_written_as_one():
+    assert python_to_sql(Literal[1, 2]) is python_to_sql(Literal[1, 2])
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/lib/test_python_to_sql.py
+++ b/tests/unit/lib/test_python_to_sql.py
@@ -115,6 +115,10 @@ class PlainKind(enum.Enum):
     A = "a"
 
 
+class ZeroFlag(enum.IntFlag):
+    NONE = 0
+
+
 @pytest.mark.parametrize(
     "annotation,expected",
     [
@@ -123,6 +127,9 @@ class PlainKind(enum.Enum):
         pytest.param(Literal[1, 2], Int64, id="int-literal"),
         pytest.param(Literal["a", "b"], String, id="str-literal"),
         pytest.param(Literal[True, False], Boolean, id="bool-literal"),
+        pytest.param(Literal[IntKind.ONE], Int64, id="literal-of-int-enum"),
+        pytest.param(Literal[StrKind.A], String, id="literal-of-str-enum"),
+        pytest.param(ZeroFlag, Int64, id="zero-only-int-flag"),
         pytest.param(
             Literal["a", None],  # noqa: PYI061
             String,
@@ -140,7 +147,7 @@ def test_values_decide_the_column_type(annotation, expected):
         pytest.param(PlainKind, id="plain-enum"),
         pytest.param(Literal[1, True], id="bool-is-not-int"),
         pytest.param(Literal[1, "a"], id="mixed-categories"),
-        pytest.param(Literal[IntKind.ONE], id="literal-of-enum-members"),
+        pytest.param(str | Literal[1], id="str-beside-an-int-literal"),
     ],
 )
 def test_values_with_no_single_column_type_are_refused(annotation):

--- a/tests/unit/test_query_steps_hash.py
+++ b/tests/unit/test_query_steps_hash.py
@@ -1,11 +1,13 @@
 import hashlib
 import math
+from unittest.mock import patch
 
 import pytest
 import sqlalchemy as sa
 from pydantic import BaseModel
 
 import datachain as dc
+import datachain.lib.udf
 from datachain import C, func
 from datachain.dataset import DatasetRecord, DatasetVersion
 from datachain.func.func import Func
@@ -297,37 +299,37 @@ def test_subtract_hash(test_session, numbers_dataset, on):
             double,
             ["x"],
             {"double": int},
-            "e9e4cdfede6099e64e14ff7d430e06d5a9a4d5dc8f8fba78a4f4c40028ef0e8f",
+            "00828a30a1bcd1b6be89443eb29155566f1452314e32a31688a4fbb09cb66b56",
         ),
         (
             double2,
             ["y"],
             {"double": int},
-            "96f977f42fe3c62fad9be25a531640dced494853688d470d3bf52db6d2b7b060",
+            "a226c2a7b79c4dd564de8b87435232e75081960099334caa0a73a7f2abc1db0e",
         ),
         (
             double_default,
             ["x"],
             {"double": int},
-            "e378641fcae870650e1df5ce85d09958d9e37471885758aec09db02bf69b694d",
+            "4a482cce48f0355a7bab70f8e7fed5e359abe6a268ea734d2d3c602429172a28",
         ),
         (
             double_kwonly,
             ["x"],
             {"double": int},
-            "e56df26ab8c36a91849fa83db952050eb6a8ab34ebd7f0f17b85cfe1672d2cd6",
+            "3806199b9f26447c3a4d35906db56a0606e8be749cc2d05c95bc68b76f999c3a",
         ),
         (
             map_custom_feature,
             ["t1"],
             {"x": CustomFeature},
-            "8184307469b77db524fd7c894f198f69c8df59656f8ff1c9dbbfb72ce8463d82",
+            "0a65e2a71ad56a0885dc2946d3eb671691301fce145bc340a498699d9ff6467c",
         ),
         (
             DoubleMapper(),
             ["x"],
             {"double": int},
-            "b637c07c491ef521674e859c6c97ec45535866775ab69063e7ac86f2f86f0f15",
+            "93959fba32e813329f25f6da3bd44efe05fdebbb6016fa8fc4c089e8d2d40226",
         ),
     ],
 )
@@ -349,25 +351,25 @@ def test_udf_mapper_hash(
             double_gen,
             ["x"],
             {"double": int},
-            "0eb1120e9508b7fb89349546ede72041945b51f3c6fcb6687be37aa9ce7aeeb2",
+            "e9383ecc5ce95415712703bcde1bb7497970725e75558886f853f228d8a154a3",
         ),
         (
             double_gen_multi_arg,
             ["x", "y"],
             {"double": int},
-            "137ebc9250861f45192914d7e111546fa010d726ccea2b75b12384a16c9eb73f",
+            "c449bd01564036355dba07fb413190736d05227cedf6e5957ad2362c5c123104",
         ),
         (
             custom_feature_gen,
             ["t1"],
             {"x": CustomFeature},
-            "15b296e6096cac42ac39d234f943e34830cda0d4005440a6f269ef3fc2d8bad4",
+            "cb997dc1c0520eff030f95c56a3aff2710a672098b40cbfe822336921357da4e",
         ),
         (
             TripleGenerator(),
             ["x"],
             {"triple": int},
-            "87395518564cfd14c04cb10f145f8ed919126becccdf00646ffdbbd2874ef224",
+            "c5847628a5054535c9fd1cc82577f9687f8bfcf9a6cf869dea900436c7d54f3d",
         ),
     ],
 )
@@ -390,14 +392,14 @@ def test_udf_generator_hash(
             ["x"],
             {"double": int},
             [C("x")],
-            "ada89641522f11fb504662ec1cae6247073ef123604e64a8fd56361bf234b194",
+            "b33eb0499464e40d234f88826f92b75a5e5494201ebbc0a14eb586ec4baeaccd",
         ),
         (
             custom_feature_gen,
             ["t1"],
             {"x": CustomFeature},
             [C.t1.my_name],
-            "7fd56d4a2af9dbd9506023bf30aab77673dade2610b7f12d66cb2377de4b59fe",
+            "ca165e80f74d8392851e8b75cbd71f29de7232f0a9fe14b0cf0cc55b036f01ea",
         ),
     ],
 )
@@ -477,3 +479,23 @@ def test_a_udf_hash_follows_the_physical_column_types():
     assert _physical_schema_hash(as_json) == _physical_schema_hash(
         SignalSchema({"v": int})
     )
+
+
+@pytest.mark.parametrize("multi_output", [False, True], ids=["single", "multi"])
+def test_the_physical_fingerprint_reaches_every_udf_hash(multi_output):
+    # A UDF that overrides hash() -- _MultiSignalMapper does, and a user
+    # subclass may -- must not be able to drop the framework's own key, or a
+    # checkpoint written under different physical types would be reused.
+    def one(i: int) -> int:
+        return i
+
+    def two(i: int) -> int:
+        return i
+
+    chain = dc.read_values(i=[1])
+    chain = chain.map(a=one, b=two) if multi_output else chain.map(a=one)
+    udf = [s for s in chain._query.steps if hasattr(s, "udf")][-1].udf
+
+    before = udf.hash()
+    with patch.object(datachain.lib.udf, "_physical_schema_hash", lambda _: "ff" * 32):
+        assert udf.hash() != before

--- a/tests/unit/test_query_steps_hash.py
+++ b/tests/unit/test_query_steps_hash.py
@@ -10,7 +10,12 @@ from datachain import C, func
 from datachain.dataset import DatasetRecord, DatasetVersion
 from datachain.func.func import Func
 from datachain.lib.signal_schema import SignalSchema
-from datachain.lib.udf import Aggregator, Generator, Mapper
+from datachain.lib.udf import (
+    Aggregator,
+    Generator,
+    Mapper,
+    _physical_schema_hash,
+)
 from datachain.lib.udf_signature import UdfSignature
 from datachain.query.dataset import (
     QueryStep,
@@ -292,37 +297,37 @@ def test_subtract_hash(test_session, numbers_dataset, on):
             double,
             ["x"],
             {"double": int},
-            "4004b6ee6ef90934d0f48fcb337d73c6552fcf6e5d8250d652d310b849dbdca7",
+            "e9e4cdfede6099e64e14ff7d430e06d5a9a4d5dc8f8fba78a4f4c40028ef0e8f",
         ),
         (
             double2,
             ["y"],
             {"double": int},
-            "98eed82d9e4ca5217d325f1182c96789390b2743d3b09739b84e50420f10cb4f",
+            "96f977f42fe3c62fad9be25a531640dced494853688d470d3bf52db6d2b7b060",
         ),
         (
             double_default,
             ["x"],
             {"double": int},
-            "40e456055a765697bfebb8371e4b3c7c3125aea100e25505d8af09155c9b6a8e",
+            "e378641fcae870650e1df5ce85d09958d9e37471885758aec09db02bf69b694d",
         ),
         (
             double_kwonly,
             ["x"],
             {"double": int},
-            "221364c9949afdb25aff731ee6b2db815ecd62ed5a713f58190d341ffe608ac4",
+            "e56df26ab8c36a91849fa83db952050eb6a8ab34ebd7f0f17b85cfe1672d2cd6",
         ),
         (
             map_custom_feature,
             ["t1"],
             {"x": CustomFeature},
-            "728657607131969e66f374374c353987801e6abc724b8a8c12edd44bccc33380",
+            "8184307469b77db524fd7c894f198f69c8df59656f8ff1c9dbbfb72ce8463d82",
         ),
         (
             DoubleMapper(),
             ["x"],
             {"double": int},
-            "b58c9679ed454d3f54b4a754585727697a9aea9e4725bd12a842a774b5087963",
+            "b637c07c491ef521674e859c6c97ec45535866775ab69063e7ac86f2f86f0f15",
         ),
     ],
 )
@@ -344,25 +349,25 @@ def test_udf_mapper_hash(
             double_gen,
             ["x"],
             {"double": int},
-            "36c34c7c957ab0ba6210a49542ec3c9d6cc9d3c632a4752b1eee04e5c2ffdc2f",
+            "0eb1120e9508b7fb89349546ede72041945b51f3c6fcb6687be37aa9ce7aeeb2",
         ),
         (
             double_gen_multi_arg,
             ["x", "y"],
             {"double": int},
-            "1a39881c75054e4c548233d1ea0dff8f57488b060015fb820ff6ccf054fc60d3",
+            "137ebc9250861f45192914d7e111546fa010d726ccea2b75b12384a16c9eb73f",
         ),
         (
             custom_feature_gen,
             ["t1"],
             {"x": CustomFeature},
-            "990f4218dfcdcf9e5cecb07d6996e571c1144d9a52b207ca026de8b89918f091",
+            "15b296e6096cac42ac39d234f943e34830cda0d4005440a6f269ef3fc2d8bad4",
         ),
         (
             TripleGenerator(),
             ["x"],
             {"triple": int},
-            "01201327b1926788e6242d2be5383c63b97ec018232ab0844f047cf64ec2dfca",
+            "87395518564cfd14c04cb10f145f8ed919126becccdf00646ffdbbd2874ef224",
         ),
     ],
 )
@@ -385,14 +390,14 @@ def test_udf_generator_hash(
             ["x"],
             {"double": int},
             [C("x")],
-            "037a9753bfc2921557b48e6fbddc3ddadb6b1ac4e5a134e565d9d9181e5d930d",
+            "ada89641522f11fb504662ec1cae6247073ef123604e64a8fd56361bf234b194",
         ),
         (
             custom_feature_gen,
             ["t1"],
             {"x": CustomFeature},
             [C.t1.my_name],
-            "fbdacb85da356170053b297f887bcb3a70c9469a2fd65bcf935809e66a014860",
+            "7fd56d4a2af9dbd9506023bf30aab77673dade2610b7f12d66cb2377de4b59fe",
         ),
     ],
 )
@@ -459,3 +464,16 @@ def test_query_step_hash_uses_version_uuid():
     ds.versions[0].uuid = uuid1
     ds.name = "completely_different_name"
     assert QueryStep(None, ds, "1.0.0").hash() == hash1
+
+
+def test_a_udf_hash_follows_the_physical_column_types():
+    # The logical schema does not move when an annotation starts mapping to a
+    # different SQL type, so without this a checkpoint written before such a
+    # change would be reused under the new one and read back as the wrong type.
+    as_json = SignalSchema({"v": int})
+    assert _physical_schema_hash(as_json) != _physical_schema_hash(
+        SignalSchema({"v": str})
+    )
+    assert _physical_schema_hash(as_json) == _physical_schema_hash(
+        SignalSchema({"v": int})
+    )


### PR DESCRIPTION
`tuple[int, ...]` is stored as `Array(JSON)` rather than `Array(Int64)`. `...` is
a real object — `Ellipsis` — so it turns up as an entry in the type's arguments:

```
tuple[int, ...]   get_args -> (int, Ellipsis)
tuple[int, int]   get_args -> (int, int)
```

`_list_to_array` saw `int` and `Ellipsis`, concluded "mixed", and fell back to
JSON — the right answer for `tuple[int, str]` and the wrong one here. It is read
as variable length only where it means that: **tuple origin, two arguments,
`Ellipsis` second**. Anywhere else it stays unresolvable, so `list[int, ...]` is
not quietly accepted as `list[int]`.

| annotation | before | after |
| --- | --- | --- |
| `tuple[int, ...]` | `Array(JSON)` | `Array(Int64)` |
| `tuple[int \| None, ...]` | `Array(JSON)` | `Array(Nullable(Int64))` |
| `tuple[int, str]` | `Array(JSON)` | unchanged — genuinely mixed |
| `list[int, ...]` | `Array(JSON)` | unchanged — not a valid annotation |

## Element mappings this makes reachable

Honouring the element type exposed two mappings that were harmless only while
everything landed in `Array(JSON)`:

- an enum mapped to the **builtin `str`**, which is not a column type at all, so
  `tuple[IntEnum, ...].to_dict()` raised
- a `Literal` mapped to `String` whatever it held, so `tuple[Literal[1, 2], ...]`
  carried integers in a string column

Both now follow the values, compared by exact type:

| annotation | maps to |
| --- | --- |
| `IntEnum`, `Literal[1, 2]`, `Literal[1] \| Literal[2]` | `Int64` |
| str-mixin `Enum`, `StrEnum`, `Literal["a", "b"]` | `String` |
| float-backed `Enum` | `Float` |
| `Literal[True, False]` | `Boolean` |
| `Literal["a", None]` | `String` — the `None` is nullability's business |
| `Literal[None]` | `String` — only ever holds NULL |
| `Literal[1, True]`, `Literal[1, "a"]`, plain `Enum` | **refused** |

`Literal[1] | Literal[2]` holds the same values as `Literal[1, 2]` and now
reaches the same type. Mixed categories are refused rather than mapped to JSON:
JSON cannot tell a stored `"1"` from the number, so one arm would come back as
the other's type. A plain enum raises rather than returning the builtin `str` —
that is what lets an array fall back to JSON, as before.

## Checkpoints

Changing which SQL type an annotation maps to leaves the **logical** schema hash
untouched, so a checkpoint written before this would be reused after it and its
rows read back as the wrong thing — `(1, 2)` as `("1", "2")`, under metadata
claiming integers.

A fingerprint of the flattened physical types (`SQLType.to_dict()`, sorted keys,
nested `item_type` and `dc_nullable` included) now goes into the UDF hash, from
which both the completed and partial checkpoint keys derive. It is mixed in at
`UDFAdapter.hash` rather than `UDFBase.hash`, because `_MultiSignalMapper`
overrides `hash()` and a user subclass may too — a multi-output map carried
neither protection otherwise. The recorded hashes in `test_query_steps_hash` move
for that reason.

## Compatibility

- **Old data still reads.** A column written as `Array(JSON)` holds `["1","2"]`;
  the read path accepts that and hydrates `(1, 2)`.
- **Comparisons across the boundary do not hold.** Same value, same declared
  schema, different stored text, so `merge(on=...)`, `distinct`, `subtract` and
  grouping disagree between a dataset written before and one written after.
  Nothing marks which codec a column was written with — hence the fingerprint.
- `Literal[1, "a"]` and plain enums are refused where they previously resolved to
  `String`. That mapping stored one arm as the other's type; failing is louder.

Premise for the array codec work in
[#1968](https://github.com/datachain-ai/datachain/issues/1968): while a variadic
scalar tuple is accidentally `Array(JSON)`, the JSON element rule cannot be made
uniform without that accident driving it.

## Stack

1. **this PR** — variadic tuple element type, element mappings, physical fingerprint
2. #1978 — canonical array conversion, codec version
3. #1976 — nullable element spellings, nullable-collection fallback
4. #1977 — optional model elements
