### PR TITLE
fix: normalize models inside collections before they reach the warehouse

### DIFF
--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator, Iterator
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -72,7 +72,7 @@ def flatten_value(value: Any, anno: Any) -> tuple:
             # Non-Optional model None (outer-merge pad): per-leaf placeholders.
             return tuple(_emit_absent(kind.inner))
         return flatten(value)
-    return (value,)
+    return (normalize_models(value, anno),)
 
 
 def flatten_list(obj_list: list[BaseModel]) -> tuple:
@@ -83,12 +83,65 @@ def flatten_list(obj_list: list[BaseModel]) -> tuple:
     )
 
 
-def _flatten_list_field(value: list) -> list:
-    assert isinstance(value, list)
-    if value and ModelStore.is_pydantic(type(value[0])):
-        return [val.model_dump() for val in value]
-    if value and isinstance(value[0], list):
-        return [_flatten_list_field(v) for v in value]
+_ERASED = (Any, object, None)
+_BARE_CONTAINERS = (dict, list, tuple, set, frozenset)
+
+
+def _may_hold_model(annotation: Any) -> bool:
+    """Whether a declared type can hold a model, erring towards yes when unsure.
+
+    An erased annotation says nothing about its contents, so it has to be walked.
+    """
+    annotation, _ = unwrap_optional(annotation)
+    if ModelStore.is_pydantic(annotation):
+        return True
+    if annotation in _ERASED:
+        return True
+    args = get_args(annotation)
+    if not args:
+        return get_origin(annotation) is not None or annotation in _BARE_CONTAINERS
+    return any(arg is not Ellipsis and _may_hold_model(arg) for arg in args)
+
+
+def _normalize_sequence(value: Any, annotation: Any) -> Any:
+    args = get_args(annotation)
+    if (
+        get_origin(annotation) is tuple
+        and args
+        and args[-1] is not Ellipsis
+        and len(args) == len(value)
+    ):
+        if not any(_may_hold_model(arg) for arg in args):
+            return value
+        return [
+            normalize_models(item, arg) for item, arg in zip(value, args, strict=True)
+        ]
+    item_type = args[0] if args else Any
+    if not _may_hold_model(item_type):
+        return value
+    return [normalize_models(item, item_type) for item in value]
+
+
+def normalize_models(value: Any, annotation: Any) -> Any:
+    """Replace models anywhere in ``value`` with their dumps, leaving the rest alone.
+
+    Collections reach storage as they are, so a model still inside one arrives at
+    the warehouse live and is converted there instead -- by different rules, and
+    for a mapping only after Pydantic has already merged keys that collide. What
+    the declared type cannot hold is returned untouched, so a vector of numbers is
+    never copied.
+    """
+    annotation, _ = unwrap_optional(annotation)
+    if ModelStore.is_pydantic(type(value)):
+        return value.model_dump()
+    if isinstance(value, (list, tuple)):
+        return _normalize_sequence(value, annotation)
+    if isinstance(value, dict):
+        args = get_args(annotation)
+        value_type = args[1] if len(args) == 2 else Any
+        if not _may_hold_model(value_type):
+            return value
+        return {key: normalize_models(item, value_type) for key, item in value.items()}
     return value
 
 
@@ -109,13 +162,8 @@ def _flatten_fields_values(fields: dict, obj: BaseModel) -> Generator[Any, None,
         kind = classify_field(f_info.annotation)
         # Direct attribute access skips Pydantic's model_dump().
         value = getattr(obj, name)
-        if isinstance(value, list):
-            yield _flatten_list_field(value)
-        elif isinstance(value, dict):
-            yield {
-                key: val.model_dump() if ModelStore.is_pydantic(type(val)) else val
-                for key, val in value.items()
-            }
+        if isinstance(value, (list, tuple, dict)):
+            yield normalize_models(value, f_info.annotation)
         elif kind.is_model:
             if kind.is_optional:
                 if value is None:

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -947,6 +947,37 @@ def test_map_hydrates_models_in_optional_dict_param(test_session):
     assert chain.to_values("count") == [3]
 
 
+class _Crate(DataModel):
+    n: int
+
+
+def _stored_field(test_session, name, annotation, value):
+    holder = type("Holder", (DataModel,), {"__annotations__": {"field": annotation}})
+    dc.read_values(c=[holder(field=value)], session=test_session).save(name)
+
+    catalog = test_session.catalog
+    table = catalog.warehouse.dataset_rows(
+        catalog.get_dataset(name, versions=["1.0.0"])
+    )
+    (row,) = catalog.warehouse.db.execute(table.select(table.c("field", "c")))
+    return row[0]
+
+
+def test_save_stores_a_tuple_of_models_like_the_list_of_the_same_models(test_session):
+    as_list = _stored_field(test_session, "as_list", list[_Crate], [_Crate(n=1)])
+    as_tuple = _stored_field(
+        test_session, "as_tuple", tuple[_Crate, ...], (_Crate(n=1),)
+    )
+
+    assert as_tuple == as_list
+
+
+def test_save_leaves_a_collection_without_models_alone(test_session):
+    stored = _stored_field(test_session, "plain", tuple[int, int], (1, 2))
+
+    assert stored == [1, 2]
+
+
 def test_map_hydrates_models_in_variadic_tuple_param(test_session):
     class TupleCollection(DataModel):
         items: tuple[MyFr, ...]

--- a/tests/unit/lib/test_signal_schema.py
+++ b/tests/unit/lib/test_signal_schema.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 from typing_extensions import TypedDict
 
 from datachain import Column, DataModel, Sys, func
-from datachain.lib.convert.flatten import flatten
+from datachain.lib.convert.flatten import flatten, flatten_value
 from datachain.lib.data_model import is_mapping_annotation
 from datachain.lib.file import File, TextFile
 from datachain.lib.model_store import ModelStore
@@ -1578,6 +1578,70 @@ def test_signal_resolving_type_error_with_unpicklable_field():
     restored = pickle.loads(pickle.dumps(err))  # noqa: S301
     assert str(restored) == str(err)
     assert type(restored) is SignalResolvingTypeError
+
+
+class _Boxed(BaseModel):
+    n: int
+
+
+@pytest.mark.parametrize(
+    "annotation,value,expected",
+    [
+        (list[_Boxed], [_Boxed(n=1)], [{"n": 1}]),
+        (tuple[_Boxed, ...], (_Boxed(n=1),), [{"n": 1}]),
+        (dict[str, list[_Boxed]], {"k": [_Boxed(n=1)]}, {"k": [{"n": 1}]}),
+        (dict[str, _Boxed], {"k": _Boxed(n=1)}, {"k": {"n": 1}}),
+        (tuple[tuple[_Boxed, ...], ...], ((_Boxed(n=1),),), [[{"n": 1}]]),
+        (dict[str, Any], {"k": _Boxed(n=1)}, {"k": {"n": 1}}),
+        (Optional[list[_Boxed]], [_Boxed(n=1)], [{"n": 1}]),
+        (Union[None, list[_Boxed]], [_Boxed(n=1)], [{"n": 1}]),
+        (tuple[_Boxed, int], (_Boxed(n=1), 7), [{"n": 1}, 7]),
+        (tuple[int, _Boxed], (7, _Boxed(n=1)), [7, {"n": 1}]),
+        (tuple[int, int], (1, 2), (1, 2)),
+        (list[int], [1, 2], [1, 2]),
+    ],
+    ids=[
+        "list",
+        "tuple",
+        "dict-of-lists",
+        "dict-of-models",
+        "nested-tuples",
+        "erased-dict-value",
+        "optional-first",
+        "optional-last",
+        "fixed-tuple-model-first",
+        "fixed-tuple-model-last",
+        "tuple-without-models",
+        "list-without-models",
+    ],
+)
+def test_flatten_normalizes_models_in_any_collection(annotation, value, expected):
+    holder = type("Holder", (BaseModel,), {"__annotations__": {"field": annotation}})
+
+    assert flatten(holder(field=value)) == (expected,)
+
+
+@pytest.mark.parametrize(
+    "annotation,value,expected",
+    [
+        (list[_Boxed], [_Boxed(n=1)], [{"n": 1}]),
+        (dict[str, _Boxed], {"k": _Boxed(n=1)}, {"k": {"n": 1}}),
+        (tuple[_Boxed, ...], (_Boxed(n=1),), [{"n": 1}]),
+        (list[int], [1, 2], [1, 2]),
+    ],
+    ids=["list", "dict", "tuple", "no-models"],
+)
+def test_flatten_value_normalizes_udf_output(annotation, value, expected):
+    assert flatten_value(value, annotation) == (expected,)
+
+
+def test_flatten_does_not_copy_a_collection_without_models():
+    class Holder(BaseModel):
+        field: list[int]
+
+    holder = Holder(field=[1, 2, 3])
+
+    assert flatten(holder)[0] is holder.field
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The same model is stored two different ways depending on the container it sits in.

```python
class Item(dc.DataModel):
    n: int

class InList(dc.DataModel):
    items: list[Item]

class InTuple(dc.DataModel):
    items: tuple[Item, ...]
```

What lands in the column:

```
list[Item]        [{"n":1}]        an object
tuple[Item, ...]  ["{\"n\":1}"]    a string holding JSON
```

## Why

A model inside a `list` is replaced by its dump before it reaches storage. Inside a tuple, a mapping value, or a UDF's returned collection it is not — it arrives live and the warehouse converts it there instead, by different rules.

Two places decide this and neither did it completely:

- `_flatten_fields_values` chose from the **runtime type** of the value and knew only `list` and `dict`. Its `dict` branch converted a value that *was* a model, but not one that was a list of them.
- `flatten_value`, which UDF outputs go through, converted nothing unless the whole annotation was a model — so a UDF returning `list[Item]` handed over live models.

Both now share one normalizer that walks by **declared type**.

## What that buys, beyond consistency

| in a `tuple[Model, ...]` | before | after |
|---|---|---|
| numpy field | **fails to save** | works |
| redacting `when_used="json"` serializer | persists `'***'`, original lost | stores the real value |
| `Decimal` | `"1.20"` | `1.2`, same as a list |
| `Path` field | works | fails, as in every other shape |

The serializer row is the one worth reading twice: a serializer written to hide a value in an API response was deciding what went into the database, and the original was unrecoverable.

## Deciding from the annotation

- A type that cannot hold a model is returned untouched, so `list[int]` is never copied — and this holds per element, so `tuple[Item, list[int]]` converts the model and leaves the list alone.
- `Optional` is unwrapped before arguments are read, so `list[Item] | None` and `None | list[Item]` behave identically.
- Elements are converted one at a time rather than from whatever the first one is, which `tuple[Item, int]` needs.
- An erased annotation — `Any`, `object`, a bare container — says nothing about its contents, so it is walked rather than assumed model-free.

## Compatibility

`tuple[Model, ...]` columns written before this will not compare equal to ones written after — `filter`, `distinct`, `subtract`, `merge`. **Reads are unaffected**: verified by writing such a column on `main` and reading it here, where both spellings load as the declared tuple.

## Relationship to #1943

Independent — neither needs the other. But together they close two of that PR's strict `xfail`s: a colliding mapping inside a live model reaches `model_dump(mode="json")`, which merges the keys before anything can inspect them. Normalizing first means it arrives as a plain dict and the existing check sees both keys. UDF-returned `list[Model]` and `dict[str, Model]` are covered too. Whichever lands second should flip those markers.
