### PR TITLE
fix: convert each element of a model list on its own

### DIFF
--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -85,11 +85,18 @@ def flatten_list(obj_list: list[BaseModel]) -> tuple:
 
 def _flatten_list_field(value: list) -> list:
     assert isinstance(value, list)
-    if value and ModelStore.is_pydantic(type(value[0])):
-        return [val.model_dump() for val in value]
-    if value and isinstance(value[0], list):
-        return [_flatten_list_field(v) for v in value]
-    return value
+    converted = [_flatten_list_item(item) for item in value]
+    if all(item is same for item, same in zip(value, converted, strict=True)):
+        return value
+    return converted
+
+
+def _flatten_list_item(item: Any) -> Any:
+    if ModelStore.is_pydantic(type(item)):
+        return item.model_dump()
+    if isinstance(item, list):
+        return _flatten_list_field(item)
+    return item
 
 
 def _leaf_count(model: type[BaseModel]) -> int:

--- a/tests/unit/lib/test_feature.py
+++ b/tests/unit/lib/test_feature.py
@@ -66,6 +66,35 @@ def test_flatten_nested():
     assert flatten(t1) == ("sfo", "sf", 567, {"42": 999}, 1849)
 
 
+class _Point(BaseModel):
+    x: int
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ([_Point(x=1), 7], [{"x": 1}, 7]),
+        ([7, _Point(x=1)], [7, {"x": 1}]),
+        ([[_Point(x=1)], [7]], [[{"x": 1}], [7]]),
+    ],
+    ids=["model-first", "model-last", "nested"],
+)
+def test_flatten_list_field_converts_each_element(value, expected):
+    class Holder(BaseModel):
+        items: list
+
+    assert flatten(Holder(items=value)) == (expected,)
+
+
+def test_flatten_list_field_keeps_a_list_without_models():
+    class Holder(BaseModel):
+        items: list[int]
+
+    holder = Holder(items=[1, 2, 3])
+
+    assert flatten(holder)[0] is holder.items
+
+
 def test_flatten_list_field():
     class Trace(BaseModel):
         x: int


### PR DESCRIPTION
A list holding both a model and something else fails to save:

```python
class Reading(dc.DataModel):
    n: int

class Holder(dc.DataModel):
    items: list[Reading | int]

dc.read_values(h=[Holder(items=[Reading(n=1), 7])]).save("h")
# AttributeError: 'int' object has no attribute 'model_dump'
```

Write the same list the other way round and it saves, but stores the model unconverted:

```
[Reading(n=1), 7]   ->  AttributeError
[7, Reading(n=1)]   ->  saves, model left live for the warehouse to encode by its own rules
```

## Why

`_flatten_list_field` decided what the whole list contained from its **first element**:

```python
if value and ModelStore.is_pydantic(type(value[0])):
    return [val.model_dump() for val in value]   # every element, model or not
if value and isinstance(value[0], list):
    return [_flatten_list_field(v) for v in value]
return value                                     # no element converted
```

So a mixed list either crashes on the first non-model or silently converts none of them, depending on what happens to be at index 0.

Each element is now handled on its own. A list where nothing changed is returned as it is rather than rebuilt, so a list of numbers is not copied.

## Scope

Only mixed lists change behaviour — they crash or store wrongly today. A list that is entirely models, or entirely not, is unaffected, so no existing stored data changes.
