### PR TITLE
feat: encode the remaining types Pydantic's JSON mode knows

### DIFF
--- a/src/datachain/json.py
+++ b/src/datachain/json.py
@@ -8,7 +8,10 @@ All code inside DataChain should import this module instead of using
 """
 
 import datetime as _dt
+import enum as _enum
+import ipaddress as _ipaddress
 import json as _json
+import pathlib as _pathlib
 import sys as _sys
 import uuid as _uuid
 from collections.abc import Callable
@@ -46,6 +49,27 @@ def _format_datetime(value: _dt.datetime) -> str:
     return iso
 
 
+def _format_timedelta(value: _dt.timedelta) -> str:
+    """ISO 8601 duration, matching what Pydantic's JSON mode writes."""
+    seconds = value.total_seconds()
+    sign = "-" if seconds < 0 else ""
+    seconds = abs(seconds)
+    days, rest = divmod(seconds, 86400)
+    hours, rest = divmod(rest, 3600)
+    minutes, secs = divmod(rest, 60)
+    parts = f"{sign}P"
+    if days:
+        parts += f"{int(days)}D"
+    parts += "T"
+    if hours:
+        parts += f"{int(hours)}H"
+    if minutes:
+        parts += f"{int(minutes)}M"
+    if secs or parts.endswith("T"):
+        parts += f"{secs:g}S"
+    return parts
+
+
 def _format_time(value: _dt.time) -> str:
     iso = value.isoformat()
 
@@ -71,6 +95,17 @@ def _coerce(value: Any, serialize_bytes: bool, serialize_numpy: bool) -> Any:
         converted = _format_time(value)
     elif isinstance(value, _uuid.UUID):
         converted = str(value)
+    elif isinstance(value, _dt.timedelta):
+        converted = _format_timedelta(value)
+    elif isinstance(
+        value,
+        (_pathlib.PurePath, _ipaddress.IPv4Address, _ipaddress.IPv6Address),
+    ):
+        converted = str(value)
+    elif isinstance(value, _enum.Enum):
+        converted = value.value
+    elif isinstance(value, (set, frozenset)):
+        converted = list(value)
 
     if converted is _SENTINEL and serialize_numpy:
         converted = _coerce_numpy(value)

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -1,10 +1,13 @@
 import datetime as dt
+import enum
 import io
+import ipaddress
+import pathlib
 import sys
 
 import numpy as np
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from datachain import json
 
@@ -69,6 +72,55 @@ def test_datetime_serialization_matches_pydantic_json_mode() -> None:
         )
         == expected
     )
+
+
+class _Grade(enum.Enum):
+    FIRST = 1
+
+
+class _Colour(str, enum.Enum):
+    RED = "red"
+
+
+class ExtraPayload(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    span: dt.timedelta
+    long_span: dt.timedelta
+    path: pathlib.PurePosixPath
+    ipv4: ipaddress.IPv4Address
+    ipv6: ipaddress.IPv6Address
+    grade: _Grade
+    colour: _Colour
+    tags: set[int]
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["span", "long_span", "path", "ipv4", "ipv6", "grade", "colour", "tags"],
+)
+def test_extra_types_match_pydantic_json_mode(field: str) -> None:
+    payload = ExtraPayload(
+        span=dt.timedelta(seconds=90),
+        long_span=dt.timedelta(days=2, hours=3),
+        path=pathlib.PurePosixPath("/a/b"),
+        ipv4=ipaddress.IPv4Address("1.2.3.4"),
+        ipv6=ipaddress.IPv6Address("::1"),
+        grade=_Grade.FIRST,
+        colour=_Colour.RED,
+        tags={1, 2},
+    )
+
+    assert (
+        json.loads(json.dumps(getattr(payload, field)))
+        == payload.model_dump(mode="json")[field]
+    )
+
+
+def test_extra_types_are_handled_inside_containers() -> None:
+    value = {"a": [pathlib.PurePosixPath("/x")], "b": {"c": dt.timedelta(seconds=90)}}
+
+    assert json.loads(json.dumps(value)) == {"a": ["/x"], "b": {"c": "PT1M30S"}}
 
 
 def test_numpy_serialization_is_opt_in() -> None:


### PR DESCRIPTION
A model field holding one of several ordinary types cannot be stored:

```python
class Doc(dc.DataModel):
    source: pathlib.PurePosixPath
    ttl: datetime.timedelta

class Batch(dc.DataModel):
    docs: list[Doc]

dc.read_values(b=[Batch(docs=[Doc(source=..., ttl=...)])]).save("b")
# TypeError: Object of type PurePosixPath is not JSON serializable
```

## Why it depends on where the model sits

Two things can turn a model into storable JSON, and they know different types:

| | converts with | knows |
|---|---|---|
| `flatten` | `model_dump()` — python mode | leaves Python objects for **this encoder** |
| warehouse | `model_dump(mode="json")` | **Pydantic** converts everything it knows |

Which one runs is decided by the container:

```
list[Model]        flatten     -> python mode -> this encoder
tuple[Model, ...]  warehouse   -> JSON mode   -> Pydantic
```

So the same field works in one shape and fails in the other. Measured, for a declared field type:

```
                json mode (warehouse)   python mode + this encoder
timedelta       'PT1M30S'               TypeError
PurePosixPath   '/a/b'                  TypeError
IPv4Address     '1.2.3.4'               TypeError
plain enum      1                       TypeError
set[int]        [1, 2]                  TypeError
datetime/UUID/str enum                  same
ndarray         PydanticSerializationError   [1, 2]
```

This PR closes five of those rows, plus `IPv6Address`. Each is written the way Pydantic's JSON mode writes it, and the tests assert that equivalence against `model_dump(mode="json")` rather than against a fixed string, so they stay honest if Pydantic changes.

## Scope

All six raise today, so **nothing that currently writes changes**. Eight of the nine new cases fail against `main`.

`Decimal` is deliberately left out: it already writes, as a number where Pydantic writes a string (`1.2` vs `"1.20"`), so aligning it would change stored data rather than add to it. That belongs in its own change.

This is a prerequisite for making the two converters agree — with the type gap closed, which one runs stops changing what gets written.
