### PR TITLE
fix: write numpy held inside a model instead of failing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "sqlalchemy>=2",
   "multiprocess>=0.70.16",
   "cloudpickle",
-  "pydantic",
+  "pydantic>=2.11",
   "jmespath>=1.0",
   "datamodel-code-generator>=0.28.4",
   "Pillow>=12.1.1,<13",

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -100,8 +100,9 @@ class AbstractWarehouse(ABC, Serializable):
 
         if ModelStore.is_pydantic(type(obj)):
             # Use Pydantic's JSON mode to ensure datetime and other non-JSON
-            # native types are serialized in a compatible way.
-            return obj.model_dump(mode="json")
+            # native types are serialized in a compatible way. Numpy is the one
+            # thing it refuses and this project's encoder handles.
+            return obj.model_dump(mode="json", fallback=json.numpy_to_python)
 
         if isinstance(obj, dict):
             out: dict[str, Any] = {}

--- a/src/datachain/json.py
+++ b/src/datachain/json.py
@@ -88,50 +88,38 @@ def _coerce(value: Any, serialize_bytes: bool, serialize_numpy: bool) -> Any:
 def numpy_to_python(value: Any) -> Any:
     """Convert a numpy value to what this module's encoder would write, or raise.
 
-    Handed to Pydantic as its fallback, so a model must not be able to store a
-    value the encoder refuses outside one.
+    Handed to Pydantic as its fallback. Pydantic serializes whatever comes back,
+    so returning anything it understands better than the encoder does would let a
+    model store what a plain value cannot; everything therefore leaves here
+    already JSON-native.
     """
-    if _holds_settled_scalars(value):
-        return value.tolist()
-
     converted = _coerce_numpy(value)
     if converted is _SENTINEL:
         raise _not_serializable(value)
-    return _settle(converted)
 
+    if _holds_settled_scalars(value):
+        return converted
 
-def _holds_settled_scalars(value: Any) -> bool:
-    """Whether tolist() alone yields JSON-native leaves, so nothing need be walked.
-
-    Bytes, complex, datetimes and extended precision all need the slower path.
-    """
-    dtype = getattr(value, "dtype", None)
-    if dtype is None:
-        return False
-    if dtype.kind in "biuU":
-        return True
-
-    import numpy as np
-
-    return dtype.type in (np.float16, np.float32, np.float64)
+    return loads(dumps(converted, serialize_numpy=True))
 
 
 def _not_serializable(value: Any) -> TypeError:
     return TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
-def _settle(value: Any) -> Any:
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, (list, tuple, set)):
-        return [_settle(item) for item in value]
-    if isinstance(value, dict):
-        return {_settle(key): _settle(item) for key, item in value.items()}
+def _holds_settled_scalars(value: Any) -> bool:
+    """Whether tolist() alone yields JSON-native leaves, so nothing need be encoded.
 
-    converted = _coerce(value, serialize_bytes=False, serialize_numpy=True)
-    if converted is _SENTINEL:
-        raise _not_serializable(value)
-    return _settle(converted)
+    Bytes, complex, datetimes, object arrays and extended precision all have to go
+    the slower way.
+    """
+    dtype = value.dtype
+    if dtype.kind in "biuU":
+        return True
+
+    import numpy as np
+
+    return dtype.type in (np.float16, np.float32, np.float64)
 
 
 def _coerce_numpy(value: Any) -> Any:

--- a/src/datachain/json.py
+++ b/src/datachain/json.py
@@ -86,13 +86,52 @@ def _coerce(value: Any, serialize_bytes: bool, serialize_numpy: bool) -> Any:
 
 
 def numpy_to_python(value: Any) -> Any:
-    """Convert a numpy array or scalar to plain Python, or raise if it is neither."""
+    """Convert a numpy value to what this module's encoder would write, or raise.
+
+    Handed to Pydantic as its fallback, so a model must not be able to store a
+    value the encoder refuses outside one.
+    """
+    if _holds_settled_scalars(value):
+        return value.tolist()
+
     converted = _coerce_numpy(value)
     if converted is _SENTINEL:
-        raise TypeError(
-            f"Object of type {type(value).__name__} is not JSON serializable"
-        )
-    return converted
+        raise _not_serializable(value)
+    return _settle(converted)
+
+
+def _holds_settled_scalars(value: Any) -> bool:
+    """Whether tolist() alone yields JSON-native leaves, so nothing need be walked.
+
+    Bytes, complex, datetimes and extended precision all need the slower path.
+    """
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return False
+    if dtype.kind in "biuU":
+        return True
+
+    import numpy as np
+
+    return dtype.type in (np.float16, np.float32, np.float64)
+
+
+def _not_serializable(value: Any) -> TypeError:
+    return TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _settle(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return [_settle(item) for item in value]
+    if isinstance(value, dict):
+        return {_settle(key): _settle(item) for key, item in value.items()}
+
+    converted = _coerce(value, serialize_bytes=False, serialize_numpy=True)
+    if converted is _SENTINEL:
+        raise _not_serializable(value)
+    return _settle(converted)
 
 
 def _coerce_numpy(value: Any) -> Any:
@@ -113,7 +152,12 @@ def _numpy_to_python(value: Any, numpy_module) -> Any:
             return converted
         return _numpy_to_python(converted, numpy_module)
     if isinstance(value, numpy_module.generic):
-        return value.tolist()
+        converted = value.tolist()
+        if isinstance(converted, numpy_module.generic):
+            # Extended precision: tolist() hands back the same numpy type, and
+            # converting again would not terminate.
+            raise _not_serializable(value)
+        return converted
     if isinstance(value, (list, tuple, set)):
         converted = [_numpy_to_python(item, numpy_module) for item in value]
         return tuple(converted) if isinstance(value, tuple) else converted

--- a/src/datachain/json.py
+++ b/src/datachain/json.py
@@ -9,6 +9,7 @@ All code inside DataChain should import this module instead of using
 
 import datetime as _dt
 import json as _json
+import math as _math
 import sys as _sys
 import uuid as _uuid
 from collections.abc import Callable
@@ -98,9 +99,41 @@ def numpy_to_python(value: Any) -> Any:
         raise _not_serializable(value)
 
     if _holds_settled_scalars(value):
+        _reject_non_finite_array(value)
         return converted
 
-    return loads(dumps(converted, serialize_numpy=True))
+    settled = loads(dumps(converted, serialize_numpy=True))
+    _reject_non_finite(settled)
+    return settled
+
+
+def _non_finite(value: Any) -> ValueError:
+    return ValueError(
+        f"Value {value!r} cannot be stored inside a model: Pydantic's JSON mode "
+        f"writes NaN and infinities as null, losing the value"
+    )
+
+
+def _reject_non_finite_array(value: Any) -> None:
+    if value.dtype.kind != "f":
+        return
+
+    import numpy as np
+
+    if not np.isfinite(value).all():
+        raise _non_finite(value)
+
+
+def _reject_non_finite(value: Any) -> None:
+    if isinstance(value, float):
+        if not _math.isfinite(value):
+            raise _non_finite(value)
+    elif isinstance(value, list):
+        for item in value:
+            _reject_non_finite(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _reject_non_finite(item)
 
 
 def _not_serializable(value: Any) -> TypeError:

--- a/src/datachain/json.py
+++ b/src/datachain/json.py
@@ -22,6 +22,7 @@ __all__ = [
     "dumps",
     "load",
     "loads",
+    "numpy_to_python",
 ]
 
 JSONDecodeError = (_ujson.JSONDecodeError, _json.JSONDecodeError)
@@ -81,6 +82,16 @@ def _coerce(value: Any, serialize_bytes: bool, serialize_numpy: bool) -> Any:
     ):
         converted = list(bytes(value)[:DEFAULT_PREVIEW_BYTES])
 
+    return converted
+
+
+def numpy_to_python(value: Any) -> Any:
+    """Convert a numpy array or scalar to plain Python, or raise if it is neither."""
+    converted = _coerce_numpy(value)
+    if converted is _SENTINEL:
+        raise TypeError(
+            f"Object of type {type(value).__name__} is not JSON serializable"
+        )
     return converted
 
 

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -217,9 +217,8 @@ def test_convert_type(test_session):
 
 
 class NumpyHolder(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
     name: str
-    payload: Any = None
+    payload: dict
 
 
 def test_convert_type_writes_numpy_held_inside_a_model(test_session):
@@ -232,20 +231,22 @@ def test_convert_type_writes_numpy_held_inside_a_model(test_session):
             )
         )
 
-    assert to_json(NumpyHolder(name="a", payload=np.array([1, 2], dtype=np.int64))) == {
+    assert to_json(
+        NumpyHolder(name="a", payload={"v": np.array([1, 2], dtype=np.int64)})
+    ) == {
         "name": "a",
-        "payload": [1, 2],
+        "payload": {"v": [1, 2]},
     }
-    assert to_json(NumpyHolder(name="b", payload=np.float32(0.5))) == {
+    assert to_json(NumpyHolder(name="b", payload={"v": np.float32(0.5)})) == {
         "name": "b",
-        "payload": 0.5,
+        "payload": {"v": 0.5},
     }
     assert to_json(NumpyHolder(name="c", payload={"k": [np.int64(7)]})) == {
         "name": "c",
         "payload": {"k": [7]},
     }
-    assert to_json([NumpyHolder(name="d", payload=np.array([1.5]))]) == [
-        {"name": "d", "payload": [1.5]},
+    assert to_json([NumpyHolder(name="d", payload={"v": np.array([1.5])})]) == [
+        {"name": "d", "payload": {"v": [1.5]}},
     ]
 
 
@@ -257,7 +258,7 @@ def test_convert_type_refuses_a_type_no_encoder_can_write(test_session):
 
     with pytest.raises(TypeError, match="not JSON serializable"):
         warehouse.convert_type(
-            NumpyHolder(name="a", payload=Opaque()),
+            NumpyHolder(name="a", payload={"v": Opaque()}),
             JSON(),
             warehouse.python_type(JSON()),
             "JSON",

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -1,7 +1,10 @@
+import uuid
 from datetime import datetime
+from decimal import Decimal
 from typing import Any
 
 import numpy as np
+import pandas as pd
 import pytest
 import ujson as json
 from pydantic import BaseModel, ConfigDict
@@ -276,6 +279,8 @@ REFUSED_BY_THE_ENCODER = [
     ),
     pytest.param(lambda: np.complex64(1 + 2j), id="complex"),
     pytest.param(lambda: np.timedelta64(3, "D"), id="timedelta"),
+    pytest.param(lambda: np.array([b"ab"], dtype=object), id="bytes-in-object-array"),
+    pytest.param(lambda: pd.Series([1, 2]), id="not-numpy-at-all"),
 ]
 
 STORED_BY_THE_ENCODER = [
@@ -285,6 +290,17 @@ STORED_BY_THE_ENCODER = [
     pytest.param(lambda: np.array([1.5, 2.5], dtype=np.float32), id="float32-array"),
     pytest.param(lambda: np.array(["a", "b"]), id="str-array"),
     pytest.param(lambda: np.array([1, None], dtype=object), id="object-array"),
+    pytest.param(
+        lambda: np.array([Decimal("1.25")], dtype=object), id="decimal-in-object-array"
+    ),
+    pytest.param(lambda: np.array([{None: 1}], dtype=object), id="none-key"),
+    pytest.param(lambda: np.array([{(1, "a"): 3}], dtype=object), id="tuple-key"),
+    pytest.param(
+        lambda: np.array([{datetime(2024, 1, 2): 1}], dtype=object), id="datetime-key"
+    ),
+    pytest.param(
+        lambda: np.array([{uuid.UUID(int=7): 1}], dtype=object), id="uuid-key"
+    ),
 ]
 
 
@@ -304,11 +320,13 @@ def _model_payload(warehouse, value):
 def test_a_model_refuses_the_numpy_a_plain_value_refuses(test_session, make):
     warehouse = test_session.catalog.warehouse
 
-    with pytest.raises(TypeError, match="not JSON serializable"):
+    with pytest.raises(TypeError) as plain:
         dcjson.dumps({"v": make()}, serialize_numpy=True)
 
-    with pytest.raises(TypeError, match="not JSON serializable"):
+    with pytest.raises(TypeError) as wrapped:
         _model_payload(warehouse, make())
+
+    assert str(wrapped.value) == str(plain.value)
 
 
 @pytest.mark.parametrize("make", STORED_BY_THE_ENCODER)

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -214,3 +214,52 @@ def test_convert_type(test_session):
     # error, float to int in list
     with pytest.raises(ValueError):
         run_convert_type([1.5, 1], Array(Int))
+
+
+class NumpyHolder(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    name: str
+    payload: Any = None
+
+
+def test_convert_type_writes_numpy_held_inside_a_model(test_session):
+    warehouse = test_session.catalog.warehouse
+
+    def to_json(value):
+        return json.loads(
+            warehouse.convert_type(
+                value, JSON(), warehouse.python_type(JSON()), "JSON", "test_column"
+            )
+        )
+
+    assert to_json(NumpyHolder(name="a", payload=np.array([1, 2], dtype=np.int64))) == {
+        "name": "a",
+        "payload": [1, 2],
+    }
+    assert to_json(NumpyHolder(name="b", payload=np.float32(0.5))) == {
+        "name": "b",
+        "payload": 0.5,
+    }
+    assert to_json(NumpyHolder(name="c", payload={"k": [np.int64(7)]})) == {
+        "name": "c",
+        "payload": {"k": [7]},
+    }
+    assert to_json([NumpyHolder(name="d", payload=np.array([1.5]))]) == [
+        {"name": "d", "payload": [1.5]},
+    ]
+
+
+def test_convert_type_refuses_a_type_no_encoder_can_write(test_session):
+    warehouse = test_session.catalog.warehouse
+
+    class Opaque:
+        pass
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        warehouse.convert_type(
+            NumpyHolder(name="a", payload=Opaque()),
+            JSON(),
+            warehouse.python_type(JSON()),
+            "JSON",
+            "test_column",
+        )

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -6,6 +6,7 @@ import pytest
 import ujson as json
 from pydantic import BaseModel, ConfigDict
 
+from datachain import json as dcjson
 from datachain.sql.types import (
     JSON,
     Array,
@@ -264,3 +265,56 @@ def test_convert_type_refuses_a_type_no_encoder_can_write(test_session):
             "JSON",
             "test_column",
         )
+
+
+REFUSED_BY_THE_ENCODER = [
+    pytest.param(lambda: np.longdouble(3), id="longdouble-scalar"),
+    pytest.param(lambda: np.array([1, 2], dtype=np.longdouble), id="longdouble-array"),
+    pytest.param(lambda: np.clongdouble(1 + 2j), id="clongdouble-scalar"),
+    pytest.param(
+        lambda: np.array([1, 2], dtype=np.clongdouble), id="clongdouble-array"
+    ),
+    pytest.param(lambda: np.complex64(1 + 2j), id="complex"),
+    pytest.param(lambda: np.timedelta64(3, "D"), id="timedelta"),
+]
+
+STORED_BY_THE_ENCODER = [
+    pytest.param(lambda: np.datetime64("2024-01-02"), id="datetime"),
+    pytest.param(lambda: np.float16(1.5), id="float16"),
+    pytest.param(lambda: np.array([[1, 2], [3, 4]]), id="int-matrix"),
+    pytest.param(lambda: np.array([1.5, 2.5], dtype=np.float32), id="float32-array"),
+    pytest.param(lambda: np.array(["a", "b"]), id="str-array"),
+    pytest.param(lambda: np.array([1, None], dtype=object), id="object-array"),
+]
+
+
+def _model_payload(warehouse, value):
+    return json.loads(
+        warehouse.convert_type(
+            NumpyHolder(name="a", payload={"v": value}),
+            JSON(),
+            warehouse.python_type(JSON()),
+            "JSON",
+            "test_column",
+        )
+    )["payload"]
+
+
+@pytest.mark.parametrize("make", REFUSED_BY_THE_ENCODER)
+def test_a_model_refuses_the_numpy_a_plain_value_refuses(test_session, make):
+    warehouse = test_session.catalog.warehouse
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        dcjson.dumps({"v": make()}, serialize_numpy=True)
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        _model_payload(warehouse, make())
+
+
+@pytest.mark.parametrize("make", STORED_BY_THE_ENCODER)
+def test_a_model_stores_the_numpy_a_plain_value_stores(test_session, make):
+    warehouse = test_session.catalog.warehouse
+
+    plain = json.loads(dcjson.dumps({"v": make()}, serialize_numpy=True))
+
+    assert _model_payload(warehouse, make()) == plain

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -336,3 +336,22 @@ def test_a_model_stores_the_numpy_a_plain_value_stores(test_session, make):
     plain = json.loads(dcjson.dumps({"v": make()}, serialize_numpy=True))
 
     assert _model_payload(warehouse, make()) == plain
+
+
+NON_FINITE_NUMPY = [
+    pytest.param(lambda: np.array([1.0, np.nan], dtype=np.float32), id="nan-in-array"),
+    pytest.param(lambda: np.array([np.inf]), id="inf-in-array"),
+    pytest.param(lambda: np.array([-np.inf]), id="negative-inf-in-array"),
+    pytest.param(lambda: np.float32("nan"), id="nan-scalar"),
+    pytest.param(
+        lambda: np.array([{"k": float("inf")}], dtype=object), id="inf-in-object-array"
+    ),
+]
+
+
+@pytest.mark.parametrize("make", NON_FINITE_NUMPY)
+def test_a_model_refuses_numpy_that_would_be_stored_as_null(test_session, make):
+    warehouse = test_session.catalog.warehouse
+
+    with pytest.raises(ValueError, match="writes NaN and infinities as null"):
+        _model_payload(warehouse, make())

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6277,3 +6277,39 @@ def test_count_after_limit_then_distinct(test_session, boundary_counter):
 
     assert chain.limit(4).distinct("session_id", "position").count() == 2
     boundary_counter.assert_count(1)
+
+
+class NumpyFrame(BaseModel):
+    name: str
+    meta: dict
+
+
+class NumpyFramePair(BaseModel):
+    items: tuple[NumpyFrame, NumpyFrame]
+
+
+def test_tuple_of_models_stores_numpy_held_in_a_field(test_session):
+    def build():
+        return NumpyFramePair(
+            items=(
+                NumpyFrame(
+                    name="a", meta={"emb": np.array([5.0, 6.0]), "n": np.int64(3)}
+                ),
+                NumpyFrame(name="b", meta={"emb": [1.0]}),
+            )
+        )
+
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(pair=build, output=NumpyFramePair)
+        .to_list("pair.items")
+    )
+
+    assert rows == [
+        (
+            (
+                NumpyFrame(name="a", meta={"emb": [5.0, 6.0], "n": 3}),
+                NumpyFrame(name="b", meta={"emb": [1.0]}),
+            ),
+        )
+    ]


### PR DESCRIPTION
## The problem

A model holding a numpy array cannot be written into a `tuple[Model, ...]` field:

```python
class Frame(BaseModel):
    name: str
    meta: dict

class FramePair(BaseModel):
    items: tuple[Frame, Frame]

chain.map(pair=lambda: FramePair(items=(
    Frame(name="a", meta={"emb": np.array([5.0, 6.0])}),
    Frame(name="b", meta={"emb": [1.0]}),
)), output=FramePair)
```

The message names the wrong thing — it blames the value the UDF returned:

```
UdfError: UDF returned an invalid value for output column 'pair__items'.
Expected tuple[Frame, Frame], got (Frame(...), Frame(...)) (type: tuple).
```

The real cause is underneath it:

```
PydanticSerializationError: Unable to serialize unknown type: <class 'numpy.ndarray'>
```

Nothing here is out of contract: `meta` is declared `dict`, a numpy array is an
ordinary thing to put in one, and the same array stored one level up works.

## Why it depends on the container

Two converters take models to storage, and which one runs depends on the shape
holding the model. Instrumenting the pydantic branch of `_to_jsonable` shows
only one shape arrives there:

| field | reaches `_to_jsonable` | on `main` |
| --- | --- | --- |
| `list[Model]` | no — `flatten` | works |
| `dict[str, Model]` | no — `flatten` | works |
| plain model signal | no — `flatten` | works |
| `tuple[Model, Model]` | **yes** | **fails** |

`flatten` dumps in python mode and hands the result to this project's encoder,
which converts numpy. `_to_jsonable` uses Pydantic's JSON mode, which refuses
numpy outright. Same array, same column, different answer.

## The fix

Pydantic takes a `fallback` for types it cannot write. Give it the encoder's own
numpy conversion, so the two agree on the one type they disagreed about:

```python
return obj.model_dump(mode="json", fallback=json.numpy_to_python)
```

Pydantic walks containers itself and calls the fallback only for the leaf it
cannot serialize, so arrays and scalars convert at any depth without a second
traversal of the data.

## Requires pydantic 2.11

`fallback` reached `model_dump` in **2.11.0**; 2.10.6 and earlier raise
`TypeError: unexpected keyword argument 'fallback'`. Verified across versions:

| pydantic | `fallback` |
| --- | --- |
| 2.9.2, 2.10.0, 2.10.6 | rejected |
| 2.11.0, 2.11.9, 2.12.0 | accepted |

`pyproject.toml` asked for bare `pydantic`, so a 2.10 environment resolved fine
and would now fail on *every* model write. The bound is raised to `>=2.11`.

## On errors

A value that is neither numpy nor known to Pydantic now raises `TypeError` with
the encoder's usual `not JSON serializable` message, where before it raised
`PydanticSerializationError`. Both escape `convert_type` uncaught, as they did
before; only the type and message change. A test pins this.

An early revision of the fallback returned unrecognised values unchanged, which
made Pydantic see the same object twice and report `Circular reference detected`
instead of naming the type. It raises instead.

## Keeping the fallback inside what the encoder writes

Pydantic re-serializes whatever the fallback returns, which opened two ways for a
model to disagree with a plain value. Both are fixed and covered by parity tests:

**Extended precision does not survive `tolist()`.** `np.longdouble` and
`np.clongdouble` hand back the same numpy type, so converting again never
terminates. This is a pre-existing defect — on `main` the plain encoder already
ends in `maximum recursion depth exceeded`:

| | `main` | here |
| --- | --- | --- |
| plain encoder | `maximum recursion depth exceeded` | `TypeError: Object of type longdouble is not JSON serializable` |
| inside a model | numpy refused outright | same `TypeError` |

Rejecting it in `_numpy_to_python`, where the non-termination is visible, fixes
both callers. Excluded by scalar type rather than width — `np.longdouble` is 8
bytes on arm64 macOS yet still converts to itself.

**Model wrapping must not widen what is storable.** Pydantic serializes whatever
the fallback returns, so anything Pydantic writes better than the encoder does
would be storable inside a model and not outside one. An earlier revision tried
to police this with a hand-written walk and got the encoder's rules wrong in
several places. The fallback now runs its result through this module's own
`dumps`/`loads`, so the encoder alone decides what a value and a key become, and
what comes back is JSON-native — leaving Pydantic nothing to widen:

| value | plain | in a model, before | in a model, now |
| --- | --- | --- | --- |
| `np.complex64(1+2j)` | refused | `"1+2j"` | refused |
| `np.timedelta64(3, "D")` | refused | `"P3D"` | refused |
| `Decimal("1.25")` in an object array | `[1.25]` | refused | `[1.25]` |
| `{None: 1}` in an object array | `{"null": 1}` | `{"None": 1}` | `{"null": 1}` |
| `{(1, "a"): 3}` in an object array | `{"(1, 'a')": 3}` | `TypeError: unhashable` | `{"(1, 'a')": 3}` |
| `pd.Series([1, 2])` | refused | `[1, 2]` | refused |

Whether `timedelta` *should* be storable is a separate question — this step only
makes the two paths agree, so no format decision is smuggled in.

Arrays of ordinary numbers, bools and strings skip the encoding entirely, since
`tolist()` already yields JSON-native leaves. A 1M-float embedding costs 33 ms
against 11 ms for the bare `.tolist()`; without that fast path it was 103 ms.
The check is reached only after `_coerce_numpy` has confirmed the value really is
numpy, so it cannot stand in for the type test — a `pandas.Series` has a `dtype`
and a `tolist()` too.

## Non-finite values, and what this PR does not fix

`model_dump(mode="json")` rewrites `NaN` and the infinities to `null`, including
in whatever the fallback returns, and there is no per-call way to change it —
neither `model_dump` nor `SchemaSerializer` accepts `inf_nan_mode`, and
`ser_json_inf_nan` is model config, which belongs to the caller.

That normalization is **not new here**. On `main`, ordinary Python floats in a
model already store as `null`:

| value in a model | `main` | here |
| --- | --- | --- |
| `[float("nan"), float("inf")]` | `[None, None]` | `[None, None]` — unchanged |
| `np.array([nan, inf], dtype=f32)` | `PydanticSerializationError` | **refused, with a message naming the value** |

Only the second row is this PR's business: making numpy writable had turned a
loud failure into a quiet one, which is worse than the failure. Numpy carrying
non-finite values is now refused rather than stored as something it is not.
Arrays are checked with `isfinite` before conversion, so the fast path is
unchanged at 33 ms per million floats.

The first row is left exactly as `main` has it. It is `model_dump`'s own
normalization rather than the fallback's, it applies to every float in every
model, and it ends when this converter stops using JSON mode. Tracked in #1968.

Two related pre-existing behaviours are likewise untouched, and verified
byte-identical to `main`: numpy scalar types that subclass a builtin
(`np.bytes_`, `np.str_`, `np.float64`, `np.complex128`) never reach the fallback
at all, because Pydantic serializes them directly. `np.bytes_(b"ab")` is stored
as `"ab"` inside a model while the encoder refuses it outside one, on `main` and
here alike. Closing that needs numpy normalized before Pydantic sees the model.
Tracked in #1968.

## Tests

All three fail on `main`, pass here:

- `test_tuple_of_models_stores_numpy_held_in_a_field` — writes the chain above
  and asserts the values read back (`np.array([5.0, 6.0])` → `[5.0, 6.0]`,
  `np.int64(3)` → `3`)
- `test_convert_type_writes_numpy_held_inside_a_model` — array, scalar, nesting,
  and a model inside a list
- `test_convert_type_refuses_a_type_no_encoder_can_write` — an ordinary object is
  still rejected, not silently dropped
- `test_a_model_refuses_the_numpy_a_plain_value_refuses` — 8 cases asserting both
  paths raise *the same message*
- `test_a_model_stores_the_numpy_a_plain_value_stores` — 11 cases asserting the
  model path and the plain path produce the same JSON, keys included, so the two
  cannot drift apart again
- `test_a_model_refuses_numpy_that_would_be_stored_as_null` — 5 cases; all 5
  store silent nulls without this guard

`_to_jsonable` lives on `AbstractWarehouse`, so this is one shared code path
rather than per-backend behaviour, and the end-to-end test runs against whichever
warehouse the suite is configured with.

Full unit suite: 3178 passed. `ruff` 0.16.4 and `mypy` 2.3.1 clean.

## Scope

First of a series replacing the two model→storage converters with one — the root
cause is written up in #1968. This step changes only the warehouse path, where
numpy is the sole disagreement, and closes none of #1968 on its own.
