### PR TITLE
fix: keep None in an array wherever it sits

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -180,7 +180,12 @@ class AbstractWarehouse(ABC, Serializable):
                 # inside.
                 return [self._to_jsonable(i) for i in val]
 
-            keep_none = getattr(item_type, "dc_nullable", False)
+            # A JSON item carries its own null, and already did so in either
+            # order; only a type with no in-band null needs one kept back.
+            keep_none = (
+                getattr(item_type, "dc_nullable", False)
+                and type(item_type).__name__ != "JSON"
+            )
             return [
                 i if keep_none and i is None else self.convert_type(i, *item_type_info)
                 for i in val

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -152,9 +152,12 @@ class AbstractWarehouse(ABC, Serializable):
             item_type = col_type.item_type
             item_python_type = self.python_type(item_type)
 
-            if item_python_type is dict:
-                # This backend keeps JSON items as objects and encodes the array
-                # around them, so an item is normalized but not dumped.
+            if item_python_type is dict and all(
+                i is None or isinstance(i, dict) for i in val
+            ):
+                # This backend keeps an array of JSON objects as objects and
+                # encodes the array around them. Normalizing each one instead of
+                # passing it through is what reaches a model nested inside.
                 return [self._to_jsonable(i) for i in val]
 
             item_type_info = (

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -151,13 +151,18 @@ class AbstractWarehouse(ABC, Serializable):
 
             item_python_type = self.python_type(col_type.item_type)
 
-            if item_python_type is not list:
-                if isinstance(val[0], item_python_type):
+            # None carries no type, so it cannot say what the array holds; take
+            # the first element that can. Stops immediately unless the array
+            # starts with None.
+            probe = next((i for i in val if i is not None), None)
+
+            if item_python_type is not list and probe is not None:
+                if isinstance(probe, item_python_type):
                     # SQLite ARRAY storage expects a list; tuples/sets must be
                     # converted to lists even when element types already match.
                     return list(val)
-                if item_python_type is float and isinstance(val[0], int):
-                    return [float(i) for i in val]
+                if item_python_type is float and isinstance(probe, int):
+                    return [None if i is None else float(i) for i in val]
 
             # Optimization: Reuse these values for each function call within the
             # list comprehension.
@@ -167,7 +172,12 @@ class AbstractWarehouse(ABC, Serializable):
                 type(col_type.item_type).__name__,
                 col_name,
             )
-            return [self.convert_type(i, *item_type_info) for i in val]
+            # A None element carries no type to convert, and which branch above
+            # ran must not decide whether it survives.
+            return [
+                None if i is None else self.convert_type(i, *item_type_info)
+                for i in val
+            ]
 
         # Special use case with JSON type as we save it as string
         if col_python_type is dict or col_type_name == "JSON":

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -172,8 +172,12 @@ class AbstractWarehouse(ABC, Serializable):
             # Only an array actually holding a None gets here, so nothing else
             # changes shape. Which element came first used to decide the whole
             # array's fate, and a None cannot answer for the rest of it.
-            if item_python_type is dict and all(
-                i is None or isinstance(i, dict) for i in val
+            objects = [i for i in val if i is not None]
+
+            if (
+                item_python_type is dict
+                and objects
+                and all(isinstance(i, dict) for i in objects)
             ):
                 # An array of JSON objects stays objects; normalizing each one
                 # rather than passing it through is what reaches a model nested

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -151,34 +151,38 @@ class AbstractWarehouse(ABC, Serializable):
 
             item_type = col_type.item_type
             item_python_type = self.python_type(item_type)
-
-            if item_python_type is dict and all(
-                i is None or isinstance(i, dict) for i in val
-            ):
-                # This backend keeps an array of JSON objects as objects and
-                # encodes the array around them. Normalizing each one instead of
-                # passing it through is what reaches a model nested inside.
-                return [self._to_jsonable(i) for i in val]
-
             item_type_info = (
                 item_type,
                 item_python_type,
                 type(item_type).__name__,
                 col_name,
             )
-            if item_python_type is list:
-                # A nested array is never already converted; its own items still
-                # have to go through this.
+
+            if not any(i is None for i in val):
+                if item_python_type is not list:
+                    if isinstance(val[0], item_python_type):
+                        # SQLite ARRAY storage expects a list; tuples/sets must
+                        # be converted to lists even when element types already
+                        # match.
+                        return list(val)
+                    if item_python_type is float and isinstance(val[0], int):
+                        return [float(i) for i in val]
                 return [self.convert_type(i, *item_type_info) for i in val]
 
-            # Each element answers for itself. Reading the answer off one of them
-            # made an array's fate depend on which element happened to come
-            # first, and skipped conversion the rest of it needed.
+            # Only an array actually holding a None gets here, so nothing else
+            # changes shape. Which element came first used to decide the whole
+            # array's fate, and a None cannot answer for the rest of it.
+            if item_python_type is dict and all(
+                i is None or isinstance(i, dict) for i in val
+            ):
+                # An array of JSON objects stays objects; normalizing each one
+                # rather than passing it through is what reaches a model nested
+                # inside.
+                return [self._to_jsonable(i) for i in val]
+
             keep_none = getattr(item_type, "dc_nullable", False)
             return [
-                i
-                if isinstance(i, item_python_type) or (keep_none and i is None)
-                else self.convert_type(i, *item_type_info)
+                i if keep_none and i is None else self.convert_type(i, *item_type_info)
                 for i in val
             ]
 

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -158,7 +158,7 @@ class AbstractWarehouse(ABC, Serializable):
                 col_name,
             )
 
-            if not any(i is None for i in val):
+            if type(None) not in map(type, val):
                 if item_python_type is not list:
                     if isinstance(val[0], item_python_type):
                         # SQLite ARRAY storage expects a list; tuples/sets must
@@ -172,17 +172,14 @@ class AbstractWarehouse(ABC, Serializable):
             # Only an array actually holding a None gets here, so nothing else
             # changes shape. Which element came first used to decide the whole
             # array's fate, and a None cannot answer for the rest of it.
-            objects = [i for i in val if i is not None]
-
-            if (
-                item_python_type is dict
-                and objects
-                and all(isinstance(i, dict) for i in objects)
-            ):
-                # An array of JSON objects stays objects; normalizing each one
-                # rather than passing it through is what reaches a model nested
-                # inside.
-                return [self._to_jsonable(i) for i in val]
+            if item_python_type is dict:
+                objects = [i for i in val if i is not None]
+                if objects and all(isinstance(i, dict) for i in objects):
+                    # An array of JSON objects stays objects; normalizing each
+                    # one rather than passing it through is what reaches a model
+                    # nested inside.
+                    return [self._to_jsonable(i) for i in val]
+                return [self.convert_type(i, *item_type_info) for i in val]
 
             # A JSON item carries its own null, and already did so in either
             # order; only a type with no in-band null needs one kept back.
@@ -191,7 +188,9 @@ class AbstractWarehouse(ABC, Serializable):
                 and type(item_type).__name__ != "JSON"
             )
             return [
-                i if keep_none and i is None else self.convert_type(i, *item_type_info)
+                i
+                if (keep_none and i is None) or isinstance(i, item_python_type)
+                else self.convert_type(i, *item_type_info)
                 for i in val
             ]
 

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -149,33 +149,33 @@ class AbstractWarehouse(ABC, Serializable):
             if len(val) == 0:
                 return []
 
-            item_python_type = self.python_type(col_type.item_type)
+            item_type = col_type.item_type
+            item_python_type = self.python_type(item_type)
 
-            # None carries no type, so it cannot say what the array holds; take
-            # the first element that can. Stops immediately unless the array
-            # starts with None.
-            probe = next((i for i in val if i is not None), None)
+            if item_python_type is dict:
+                # This backend keeps JSON items as objects and encodes the array
+                # around them, so an item is normalized but not dumped.
+                return [self._to_jsonable(i) for i in val]
 
-            if item_python_type is not list and probe is not None:
-                if isinstance(probe, item_python_type):
-                    # SQLite ARRAY storage expects a list; tuples/sets must be
-                    # converted to lists even when element types already match.
-                    return list(val)
-                if item_python_type is float and isinstance(probe, int):
-                    return [None if i is None else float(i) for i in val]
-
-            # Optimization: Reuse these values for each function call within the
-            # list comprehension.
             item_type_info = (
-                col_type.item_type,
+                item_type,
                 item_python_type,
-                type(col_type.item_type).__name__,
+                type(item_type).__name__,
                 col_name,
             )
-            # A None element carries no type to convert, and which branch above
-            # ran must not decide whether it survives.
+            if item_python_type is list:
+                # A nested array is never already converted; its own items still
+                # have to go through this.
+                return [self.convert_type(i, *item_type_info) for i in val]
+
+            # Each element answers for itself. Reading the answer off one of them
+            # made an array's fate depend on which element happened to come
+            # first, and skipped conversion the rest of it needed.
+            keep_none = getattr(item_type, "dc_nullable", False)
             return [
-                None if i is None else self.convert_type(i, *item_type_info)
+                i
+                if isinstance(i, item_python_type) or (keep_none and i is None)
+                else self.convert_type(i, *item_type_info)
                 for i in val
             ]
 

--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -85,14 +85,22 @@ def flatten_list(obj_list: list[BaseModel]) -> tuple:
 
 def _flatten_list_field(value: list) -> list:
     assert isinstance(value, list)
-    # A None says nothing about what the list holds, and one element cannot
-    # answer for the rest: take a homogeneous path only if every element that
-    # carries a type agrees, and leave the Nones where they are.
-    typed = [val for val in value if val is not None]
-    if typed and all(ModelStore.is_pydantic(type(val)) for val in typed):
-        return [None if val is None else val.model_dump() for val in value]
-    if typed and all(isinstance(val, list) for val in typed):
+    # A None says nothing about what the list holds, so ask the first element
+    # that carries a type -- but one element cannot answer for the rest, so the
+    # others have to agree before a shape is assumed. Ordinary values settle it
+    # on the first element and never walk the list again.
+    first = next((val for val in value if val is not None), None)
+
+    if ModelStore.is_pydantic(type(first)):
+        if all(val is None or ModelStore.is_pydantic(type(val)) for val in value):
+            return [None if val is None else val.model_dump() for val in value]
+        return value
+
+    if isinstance(first, list) and all(
+        val is None or isinstance(val, list) for val in value
+    ):
         return [None if val is None else _flatten_list_field(val) for val in value]
+
     return value
 
 

--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -85,12 +85,13 @@ def flatten_list(obj_list: list[BaseModel]) -> tuple:
 
 def _flatten_list_field(value: list) -> list:
     assert isinstance(value, list)
-    # A None says nothing about what the list holds; ask the first element that
-    # can, and leave the Nones where they are.
-    typed = next((val for val in value if val is not None), None)
-    if ModelStore.is_pydantic(type(typed)):
+    # A None says nothing about what the list holds, and one element cannot
+    # answer for the rest: take a homogeneous path only if every element that
+    # carries a type agrees, and leave the Nones where they are.
+    typed = [val for val in value if val is not None]
+    if typed and all(ModelStore.is_pydantic(type(val)) for val in typed):
         return [None if val is None else val.model_dump() for val in value]
-    if isinstance(typed, list):
+    if typed and all(isinstance(val, list) for val in typed):
         return [None if val is None else _flatten_list_field(val) for val in value]
     return value
 

--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -85,10 +85,13 @@ def flatten_list(obj_list: list[BaseModel]) -> tuple:
 
 def _flatten_list_field(value: list) -> list:
     assert isinstance(value, list)
-    if value and ModelStore.is_pydantic(type(value[0])):
-        return [val.model_dump() for val in value]
-    if value and isinstance(value[0], list):
-        return [_flatten_list_field(v) for v in value]
+    # A None says nothing about what the list holds; ask the first element that
+    # can, and leave the Nones where they are.
+    typed = next((val for val in value if val is not None), None)
+    if ModelStore.is_pydantic(type(typed)):
+        return [None if val is None else val.model_dump() for val in value]
+    if isinstance(typed, list):
+        return [None if val is None else _flatten_list_field(val) for val in value]
     return value
 
 

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -11,7 +11,6 @@ from datachain.lib.data_model import (
     NULLABLE_SCALARS,
     is_mapping_annotation,
     is_sequence_annotation,
-    unwrap_optional,
 )
 from datachain.lib.model_store import ModelStore
 from datachain.sql.types import (
@@ -92,18 +91,20 @@ def _list_to_array(typ, args):
     list_type = list_of_args_to_type(args)
     # Optional[scalar] elements map to a nullable Array element so None survives
     # (ClickHouse: Array(Nullable(T))).
-    inner, is_optional = _peel_optional(args0)
-    if is_optional and _resolves_to_nullable_scalar(inner):
+    # A fixed tuple keeps every slot in the one column, so any slot admitting a
+    # None decides the item's nullability, not just the first.
+    admits_none = any(_peel_optional(arg)[1] for arg in args if arg is not Ellipsis)
+    if admits_none and _takes_null(list_type):
         list_type = SQLType.as_nullable(list_type)
     return Array(list_type)
 
 
-def _peel_optional(annotation) -> tuple[Any, bool]:
+def _peel_optional(annotation: Any) -> tuple[Any, bool]:
     """Strip the wrappers around an element type, reporting whether it admits None.
 
-    They nest either way round -- Optional[Annotated[int, ...]] and
-    Annotated[int | None, ...] -- and a Literal can carry the None among its
-    values, so keep peeling until nothing is left to peel.
+    They nest either way round -- ``Optional[Annotated[int, ...]]`` and
+    ``Annotated[int | None, ...]`` -- and the None can be spelled as a union arm,
+    as one of a Literal's values, or as ``Literal[None]`` inside a union.
     """
     is_optional = False
     while True:
@@ -114,37 +115,42 @@ def _peel_optional(annotation) -> tuple[Any, bool]:
         if get_origin(annotation) in (Literal, LiteralEx):
             values = get_args(annotation)
             remaining = tuple(v for v in values if v is not None)
-            if len(remaining) == len(values):
-                return annotation, is_optional
-            is_optional = True
             if not remaining:
                 return type(None), True
-            annotation = Literal[remaining]
-            continue
-
-        inner, unwrapped = unwrap_optional(annotation)
-        if not unwrapped:
+            if len(remaining) != len(values):
+                is_optional = True
+                annotation = Literal[remaining]
+                continue
             return annotation, is_optional
-        is_optional = True
-        annotation = inner
+
+        if get_origin(annotation) in (Union, UnionType):
+            arms = []
+            for arm in get_args(annotation):
+                peeled, arm_optional = _peel_optional(arm)
+                if arm_optional or peeled is type(None):
+                    is_optional = True
+                if peeled is not type(None):
+                    arms.append(peeled)
+            if not arms:
+                return type(None), True
+            if len(arms) == 1:
+                annotation = arms[0]
+                continue
+            return Union[tuple(arms)], is_optional  # noqa: UP007
+
+        return annotation, is_optional
 
 
-def _resolves_to_nullable_scalar(annotation) -> bool:
-    """Whether an element annotation ends up as a scalar a NULL can sit in.
+def _takes_null(sql_type: Any) -> bool:
+    """Whether a NULL can sit in this column type.
 
-    Asking of the annotation itself misses the wrappers that resolve to one, and
-    identity misses the SQL types a user has subclassed.
+    Compared by subclass: a project or a user may have subclassed the scalar.
     """
-    try:
-        resolved = python_to_sql(annotation)
-    except TypeError:
-        return False
-
-    resolved_cls = resolved if isinstance(resolved, type) else type(resolved)
+    sql_cls = sql_type if isinstance(sql_type, type) else type(sql_type)
     for scalar in NULLABLE_SCALARS:
         nullable = python_to_sql(scalar)
         nullable_cls = nullable if isinstance(nullable, type) else type(nullable)
-        if issubclass(resolved_cls, nullable_cls):
+        if issubclass(sql_cls, nullable_cls):
             return True
     return False
 

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -85,9 +85,18 @@ def _list_to_array(typ, args):
     if args is None:
         raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
     args0 = args[0]
+    if ModelStore.is_pydantic(args0):
+        return Array(JSON())
+
     # A model element is JSON whether or not it admits a None: is_chain_type
     # accepts list[Model | None], and the union arm is all that hid the model.
-    if ModelStore.is_pydantic(args0) or _optional_model(args0) is not None:
+    # A fixed tuple keeps every slot in the one column, so every slot has to be
+    # one -- a slot this cannot read back as a model must still be refused.
+    slots = [arg for arg in args if arg is not Ellipsis]
+    if slots and all(
+        ModelStore.is_pydantic(slot) or _optional_model(slot) is not None
+        for slot in slots
+    ):
         return Array(JSON())
 
     # Resolve what the wrappers hold, not the wrappers: composed ones --

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -4,7 +4,7 @@ from enum import Enum
 from types import UnionType
 from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel
 from typing_extensions import Literal as LiteralEx
 
 from datachain.lib.data_model import (
@@ -124,9 +124,14 @@ def _optional_model(annotation: Any) -> Any:
         return None
 
     arms = [arm for arm in get_args(annotation) if arm is not type(None)]
-    if len(arms) == 1 and ModelStore.is_pydantic(arms[0]):
-        return arms[0]
-    return None
+    if len(arms) != 1 or not ModelStore.is_pydantic(arms[0]):
+        return None
+
+    # A root model dumps to whatever it wraps, and the reader only rebuilds a
+    # model from a mapping, so this one would be handed back as its bare value.
+    if isinstance(arms[0], type) and issubclass(arms[0], RootModel):
+        return None
+    return arms[0]
 
 
 def _unwrapped_for_lookup(annotation: Any) -> Any:
@@ -145,8 +150,14 @@ def _unwrapped_for_lookup(annotation: Any) -> Any:
         return annotation
 
     try:
-        python_to_sql(peeled)
+        resolved = python_to_sql(peeled)
     except TypeError:
+        return annotation
+
+    # An array has nowhere to keep the None that peeling just dropped -- only a
+    # scalar item is made nullable, and JSON carries its own null.
+    resolved_cls = resolved if isinstance(resolved, type) else type(resolved)
+    if issubclass(resolved_cls, Array):
         return annotation
     return peeled
 

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -89,11 +89,9 @@ def _list_to_array(typ, args):
         return Array(JSON())
 
     # Resolve what the wrappers hold, not the wrappers: composed ones --
-    # Annotated[str, ...] | Literal[None] -- are recognized by neither the
-    # scalar table nor the union handling on their own. Ellipsis is left in
-    # place, as it is what marks a variadic tuple.
-    peeled = tuple(arg if arg is Ellipsis else _peel_optional(arg)[0] for arg in args)
-    list_type = list_of_args_to_type(peeled)
+    # Annotated[str, ...] | Literal[None] -- are recognized by neither the scalar
+    # table nor the union handling on their own.
+    list_type = list_of_args_to_type(tuple(_unwrapped_for_lookup(a) for a in args))
 
     # Optional[scalar] elements map to a nullable Array element so None survives
     # (ClickHouse: Array(Nullable(T))). A fixed tuple keeps every slot in the one
@@ -102,6 +100,28 @@ def _list_to_array(typ, args):
     if admits_none and _takes_null(list_type):
         list_type = SQLType.as_nullable(list_type)
     return Array(list_type)
+
+
+def _unwrapped_for_lookup(annotation: Any) -> Any:
+    """What to resolve an element annotation as.
+
+    Peeling is only useful here when what is left resolves to something. It does
+    not for a Literal holding nothing but None, for Ellipsis marking a variadic
+    tuple, or for a bare model that only the union around it made resolvable, and
+    the annotation as written is what those already mapped to.
+    """
+    if annotation is Ellipsis:
+        return annotation
+
+    peeled, _ = _peel_optional(annotation)
+    if peeled is annotation:
+        return annotation
+
+    try:
+        python_to_sql(peeled)
+    except TypeError:
+        return annotation
+    return peeled
 
 
 def _peel_optional(annotation: Any) -> tuple[Any, bool]:

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -87,9 +87,7 @@ def _list_to_array(typ, args):
     args0 = args[0]
     # A model element is JSON whether or not it admits a None: is_chain_type
     # accepts list[Model | None], and the union arm is all that hid the model.
-    if ModelStore.is_pydantic(args0) or ModelStore.is_pydantic(
-        _peel_optional(args0)[0]
-    ):
+    if ModelStore.is_pydantic(args0) or _optional_model(args0) is not None:
         return Array(JSON())
 
     # Resolve what the wrappers hold, not the wrappers: composed ones --
@@ -104,6 +102,22 @@ def _list_to_array(typ, args):
     if admits_none and _takes_null(list_type):
         list_type = SQLType.as_nullable(list_type)
     return Array(list_type)
+
+
+def _optional_model(annotation: Any) -> Any:
+    """The model behind ``Model | None``, or None if that is not the shape.
+
+    Deliberately shallow: reading back a nested model is decided elsewhere and
+    does not look through Annotated, so admitting Annotated[Model, ...] | None
+    here would store it and then hand back plain dicts.
+    """
+    if get_origin(annotation) not in (Union, UnionType):
+        return None
+
+    arms = [arm for arm in get_args(annotation) if arm is not type(None)]
+    if len(arms) == 1 and ModelStore.is_pydantic(arms[0]):
+        return arms[0]
+    return None
 
 
 def _unwrapped_for_lookup(annotation: Any) -> Any:

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -93,9 +93,22 @@ def _list_to_array(typ, args):
     # Optional[scalar] elements map to a nullable Array element so None survives
     # (ClickHouse: Array(Nullable(T))).
     inner, is_optional = unwrap_optional(args0)
-    if is_optional and inner in NULLABLE_SCALARS:
+    if is_optional and _resolves_to_nullable_scalar(inner):
         list_type = SQLType.as_nullable(list_type)
     return Array(list_type)
+
+
+def _resolves_to_nullable_scalar(annotation) -> bool:
+    """Whether an element annotation ends up as a scalar a NULL can sit in.
+
+    Asking of the annotation itself misses the wrappers that resolve to one --
+    Annotated[int, ...] and Literal["a", "b"] are not int and str.
+    """
+    try:
+        resolved = python_to_sql(annotation)
+    except TypeError:
+        return False
+    return any(resolved is python_to_sql(t) for t in NULLABLE_SCALARS)
 
 
 def list_of_args_to_type(args) -> SQLType:

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -2,7 +2,7 @@ import inspect
 from datetime import datetime
 from enum import Enum
 from types import UnionType
-from typing import Annotated, Literal, Union, get_args, get_origin
+from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
 from typing_extensions import Literal as LiteralEx
@@ -92,23 +92,61 @@ def _list_to_array(typ, args):
     list_type = list_of_args_to_type(args)
     # Optional[scalar] elements map to a nullable Array element so None survives
     # (ClickHouse: Array(Nullable(T))).
-    inner, is_optional = unwrap_optional(args0)
+    inner, is_optional = _peel_optional(args0)
     if is_optional and _resolves_to_nullable_scalar(inner):
         list_type = SQLType.as_nullable(list_type)
     return Array(list_type)
 
 
+def _peel_optional(annotation) -> tuple[Any, bool]:
+    """Strip the wrappers around an element type, reporting whether it admits None.
+
+    They nest either way round -- Optional[Annotated[int, ...]] and
+    Annotated[int | None, ...] -- and a Literal can carry the None among its
+    values, so keep peeling until nothing is left to peel.
+    """
+    is_optional = False
+    while True:
+        if get_origin(annotation) is Annotated:
+            annotation = get_args(annotation)[0]
+            continue
+
+        if get_origin(annotation) in (Literal, LiteralEx):
+            values = get_args(annotation)
+            remaining = tuple(v for v in values if v is not None)
+            if len(remaining) == len(values):
+                return annotation, is_optional
+            is_optional = True
+            if not remaining:
+                return type(None), True
+            annotation = Literal[remaining]
+            continue
+
+        inner, unwrapped = unwrap_optional(annotation)
+        if not unwrapped:
+            return annotation, is_optional
+        is_optional = True
+        annotation = inner
+
+
 def _resolves_to_nullable_scalar(annotation) -> bool:
     """Whether an element annotation ends up as a scalar a NULL can sit in.
 
-    Asking of the annotation itself misses the wrappers that resolve to one --
-    Annotated[int, ...] and Literal["a", "b"] are not int and str.
+    Asking of the annotation itself misses the wrappers that resolve to one, and
+    identity misses the SQL types a user has subclassed.
     """
     try:
         resolved = python_to_sql(annotation)
     except TypeError:
         return False
-    return any(resolved is python_to_sql(t) for t in NULLABLE_SCALARS)
+
+    resolved_cls = resolved if isinstance(resolved, type) else type(resolved)
+    for scalar in NULLABLE_SCALARS:
+        nullable = python_to_sql(scalar)
+        nullable_cls = nullable if isinstance(nullable, type) else type(nullable)
+        if issubclass(resolved_cls, nullable_cls):
+            return True
+    return False
 
 
 def list_of_args_to_type(args) -> SQLType:

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -88,11 +88,16 @@ def _list_to_array(typ, args):
     if ModelStore.is_pydantic(args0):
         return Array(JSON())
 
-    list_type = list_of_args_to_type(args)
+    # Resolve what the wrappers hold, not the wrappers: composed ones --
+    # Annotated[str, ...] | Literal[None] -- are recognized by neither the
+    # scalar table nor the union handling on their own. Ellipsis is left in
+    # place, as it is what marks a variadic tuple.
+    peeled = tuple(arg if arg is Ellipsis else _peel_optional(arg)[0] for arg in args)
+    list_type = list_of_args_to_type(peeled)
+
     # Optional[scalar] elements map to a nullable Array element so None survives
-    # (ClickHouse: Array(Nullable(T))).
-    # A fixed tuple keeps every slot in the one column, so any slot admitting a
-    # None decides the item's nullability, not just the first.
+    # (ClickHouse: Array(Nullable(T))). A fixed tuple keeps every slot in the one
+    # column, so any slot admitting a None decides it, not just the first.
     admits_none = any(_peel_optional(arg)[1] for arg in args if arg is not Ellipsis)
     if admits_none and _takes_null(list_type):
         list_type = SQLType.as_nullable(list_type)

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -85,7 +85,11 @@ def _list_to_array(typ, args):
     if args is None:
         raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
     args0 = args[0]
-    if ModelStore.is_pydantic(args0):
+    # A model element is JSON whether or not it admits a None: is_chain_type
+    # accepts list[Model | None], and the union arm is all that hid the model.
+    if ModelStore.is_pydantic(args0) or ModelStore.is_pydantic(
+        _peel_optional(args0)[0]
+    ):
         return Array(JSON())
 
     # Resolve what the wrappers hold, not the wrappers: composed ones --

--- a/src/datachain/sql/types.py
+++ b/src/datachain/sql/types.py
@@ -561,6 +561,13 @@ class TypeReadConverter:
     def array(self, value, item_type, dialect):
         if value is None or item_type is None:
             return value
+        if getattr(item_type, "dc_nullable", False):
+            # A nullable element keeps its None, the way a nullable column does;
+            # float() would otherwise turn it into nan.
+            return [
+                None if x is None else item_type.on_read_convert(x, dialect)
+                for x in value
+            ]
         return [item_type.on_read_convert(x, dialect) for x in value]
 
     def json(self, value):

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -483,6 +483,16 @@ class SubclassedInt(Int64):
             ["x", None],
             id="annotated-beside-literal-none",
         ),
+        pytest.param(
+            tuple[str, Literal[None]],  # noqa: PYI061
+            ("a", None),
+            id="null-only-literal-slot",
+        ),
+        pytest.param(
+            list[Literal[None]],  # noqa: PYI061
+            [None],
+            id="null-only-literal-item",
+        ),
         pytest.param(tuple[int, int | None], (1, None), id="second-tuple-slot"),
         pytest.param(tuple[int | None, int], (None, 1), id="first-tuple-slot"),
     ],

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -473,6 +473,13 @@ class SubclassedInt(Int64):
             id="none-among-literal-values",
         ),
         pytest.param(list[SubclassedInt | None], [1, None], id="subclassed-sql-type"),
+        pytest.param(
+            list[str | Literal[None]],  # noqa: PYI061
+            ["a", None],
+            id="literal-none-in-a-union",
+        ),
+        pytest.param(tuple[int, int | None], (1, None), id="second-tuple-slot"),
+        pytest.param(tuple[int | None, int], (None, 1), id="first-tuple-slot"),
     ],
 )
 def test_convert_type_keeps_none_for_a_wrapped_nullable_scalar(
@@ -485,7 +492,7 @@ def test_convert_type_keeps_none_for_a_wrapped_nullable_scalar(
         value, col_type, warehouse.python_type(col_type), "Array", "test_column"
     )
 
-    assert converted == value
+    assert converted == list(value)
 
 
 def test_convert_type_json_encodes_an_all_none_array(test_session):

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -397,11 +397,23 @@ def test_convert_type_stores_a_json_array_the_same_wherever_none_sits(test_sessi
             value, col_type, warehouse.python_type(col_type), "Array", "test_column"
         )
 
-    none_last = to_db([{"k": 1}, None])
-    none_first = to_db([None, {"k": 1}])
+    # What an item becomes is the backend's business; that its neighbours do not
+    # change the answer is not.
+    assert to_db([{"k": 1}, None]) == list(reversed(to_db([None, {"k": 1}])))
 
-    # What an item becomes is the backend's business; that a None beside it does
-    # not change the answer is not.
-    assert none_last[1] is None
-    assert none_first[0] is None
-    assert none_last[0] == none_first[1]
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param([None, 2], id="none-first"),
+        pytest.param([1, None], id="none-last"),
+    ],
+)
+def test_convert_type_refuses_none_in_a_non_nullable_array(test_session, value):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(Int64)
+
+    with pytest.raises(ValueError, match="incompatible"):
+        warehouse.convert_type(
+            value, col_type, warehouse.python_type(col_type), "Array", "test_column"
+        )

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import ujson as json
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, RootModel
 
 from datachain import json as dcjson
 from datachain.lib.convert.python_to_sql import python_to_sql
@@ -542,3 +542,14 @@ def test_python_to_sql_refuses_a_tuple_slot_that_reads_back_wrong():
         "type": "Array",
         "item_type": {"type": "JSON"},
     }
+
+
+class RootInt(RootModel[int]):
+    pass
+
+
+def test_python_to_sql_refuses_an_optional_root_model_element():
+    # A root model dumps to its bare value, which the reader cannot rebuild into
+    # a model, so it must not be admitted by the optional-model shortcut.
+    with pytest.raises(TypeError):
+        python_to_sql(list[RootInt | None])

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -417,3 +417,26 @@ def test_convert_type_refuses_none_in_a_non_nullable_array(test_session, value):
         warehouse.convert_type(
             value, col_type, warehouse.python_type(col_type), "Array", "test_column"
         )
+
+
+class NestedItem(BaseModel):
+    n: int
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param((None, {"a": NestedItem(n=2)}), id="none-first"),
+        pytest.param(({"a": NestedItem(n=2)}, None), id="none-last"),
+    ],
+)
+def test_convert_type_leaves_no_model_in_a_json_array_holding_none(test_session, value):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(JSON())
+
+    converted = warehouse.convert_type(
+        value, col_type, warehouse.python_type(col_type), "Array", "test_column"
+    )
+
+    # Whatever shape the backend asks for, nothing unserializable may survive.
+    json.dumps(converted)

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Annotated, Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -10,6 +10,7 @@ import ujson as json
 from pydantic import BaseModel, ConfigDict
 
 from datachain import json as dcjson
+from datachain.lib.convert.python_to_sql import python_to_sql
 from datachain.sql.types import (
     JSON,
     Array,
@@ -440,3 +441,43 @@ def test_convert_type_leaves_no_model_in_a_json_array_holding_none(test_session,
 
     # Whatever shape the backend asks for, nothing unserializable may survive.
     json.dumps(converted)
+
+
+@pytest.mark.parametrize(
+    "annotation,value",
+    [
+        pytest.param(list[int | None], [1, None], id="plain-int"),
+        pytest.param(list[int | None], [None, 2], id="plain-int-none-first"),
+        pytest.param(
+            list[Annotated[int, "meta"] | None], [1, None], id="annotated-int"
+        ),
+        pytest.param(list[Literal["a", "b"] | None], ["a", None], id="literal-str"),
+        pytest.param(
+            list[Literal["a", "b"] | None], [None, "b"], id="literal-str-none-first"
+        ),
+    ],
+)
+def test_convert_type_keeps_none_for_a_wrapped_nullable_scalar(
+    test_session, annotation, value
+):
+    warehouse = test_session.catalog.warehouse
+    col_type = python_to_sql(annotation)
+
+    converted = warehouse.convert_type(
+        value, col_type, warehouse.python_type(col_type), "Array", "test_column"
+    )
+
+    assert converted == value
+
+
+def test_convert_type_json_encodes_an_all_none_array(test_session):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(SQLType.as_nullable(JSON()))
+
+    converted = warehouse.convert_type(
+        (None, None), col_type, warehouse.python_type(col_type), "Array", "test_column"
+    )
+
+    # An array with no object in it is not an array of objects; each None stays
+    # whatever JSON writes for one, as it did before.
+    assert converted == [json.dumps(None)] * 2

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -521,3 +521,24 @@ def test_convert_type_json_encodes_an_all_none_array(test_session):
     # An array with no object in it is not an array of objects; each None stays
     # whatever JSON writes for one, as it did before.
     assert converted == [json.dumps(None)] * 2
+
+
+class SlotA(BaseModel):
+    x: int
+
+
+class SlotB(BaseModel):
+    y: int
+
+
+def test_python_to_sql_refuses_a_tuple_slot_that_reads_back_wrong():
+    # Every slot of a fixed tuple shares the column, so one that cannot be read
+    # back as a model has to refuse the whole annotation rather than be stored
+    # and handed back as a plain dict.
+    with pytest.raises(TypeError):
+        python_to_sql(tuple[SlotA | None, Annotated[SlotB, "meta"] | None])
+
+    assert python_to_sql(tuple[SlotA | None, SlotB | None]).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "JSON"},
+    }

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -478,6 +478,11 @@ class SubclassedInt(Int64):
             ["a", None],
             id="literal-none-in-a-union",
         ),
+        pytest.param(
+            list[Annotated[str, "meta"] | Literal[None]],  # noqa: PYI061
+            ["x", None],
+            id="annotated-beside-literal-none",
+        ),
         pytest.param(tuple[int, int | None], (1, None), id="second-tuple-slot"),
         pytest.param(tuple[int | None, int], (None, 1), id="first-tuple-slot"),
     ],

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -443,6 +443,10 @@ def test_convert_type_leaves_no_model_in_a_json_array_holding_none(test_session,
     json.dumps(converted)
 
 
+class SubclassedInt(Int64):
+    pass
+
+
 @pytest.mark.parametrize(
     "annotation,value",
     [
@@ -455,6 +459,20 @@ def test_convert_type_leaves_no_model_in_a_json_array_holding_none(test_session,
         pytest.param(
             list[Literal["a", "b"] | None], [None, "b"], id="literal-str-none-first"
         ),
+        pytest.param(
+            list[Annotated[int | None, "meta"]], [1, None], id="optional-in-annotated"
+        ),
+        pytest.param(
+            list[Annotated[int | None, "meta"]],
+            [None, 2],
+            id="optional-in-annotated-none-first",
+        ),
+        pytest.param(
+            list[Annotated[Literal["a", None], "meta"]],  # noqa: PYI061
+            ["a", None],
+            id="none-among-literal-values",
+        ),
+        pytest.param(list[SubclassedInt | None], [1, None], id="subclassed-sql-type"),
     ],
 )
 def test_convert_type_keeps_none_for_a_wrapped_nullable_scalar(

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -19,6 +19,8 @@ from datachain.sql.types import (
     Float32,
     Float64,
     Int,
+    Int64,
+    SQLType,
     String,
 )
 from tests.utils import (
@@ -355,3 +357,52 @@ def test_a_model_refuses_numpy_that_would_be_stored_as_null(test_session, make):
 
     with pytest.raises(ValueError, match="writes NaN and infinities as null"):
         _model_payload(warehouse, make())
+
+
+@pytest.mark.parametrize(
+    "value,item_type,expected",
+    [
+        pytest.param((1, None), Int64, [1, None], id="int-none-last"),
+        pytest.param((None, 2), Int64, [None, 2], id="int-none-first"),
+        pytest.param((None, None), Int64, [None, None], id="int-all-none"),
+        pytest.param([1, None], Float, [1.0, None], id="float-none-last"),
+        pytest.param([None, 2], Float, [None, 2.0], id="float-none-first"),
+        pytest.param(["a", None], String, ["a", None], id="str-none-last"),
+        pytest.param([None, "b"], String, [None, "b"], id="str-none-first"),
+    ],
+)
+def test_convert_type_keeps_none_wherever_it_sits_in_an_array(
+    test_session, value, item_type, expected
+):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(SQLType.as_nullable(item_type))
+
+    converted = warehouse.convert_type(
+        value,
+        col_type,
+        warehouse.python_type(col_type),
+        "Array",
+        "test_column",
+    )
+
+    assert converted == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        pytest.param([{"k": 1}, None], [{"k": 1}, None], id="dict-then-none"),
+        pytest.param([None, {"k": 1}], [None, {"k": 1}], id="none-then-dict"),
+    ],
+)
+def test_convert_type_stores_a_json_array_the_same_wherever_none_sits(
+    test_session, value, expected
+):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(JSON())
+
+    converted = warehouse.convert_type(
+        value, col_type, warehouse.python_type(col_type), "Array", "test_column"
+    )
+
+    assert converted == expected

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -388,21 +388,20 @@ def test_convert_type_keeps_none_wherever_it_sits_in_an_array(
     assert converted == expected
 
 
-@pytest.mark.parametrize(
-    "value,expected",
-    [
-        pytest.param([{"k": 1}, None], [{"k": 1}, None], id="dict-then-none"),
-        pytest.param([None, {"k": 1}], [None, {"k": 1}], id="none-then-dict"),
-    ],
-)
-def test_convert_type_stores_a_json_array_the_same_wherever_none_sits(
-    test_session, value, expected
-):
+def test_convert_type_stores_a_json_array_the_same_wherever_none_sits(test_session):
     warehouse = test_session.catalog.warehouse
     col_type = Array(JSON())
 
-    converted = warehouse.convert_type(
-        value, col_type, warehouse.python_type(col_type), "Array", "test_column"
-    )
+    def to_db(value):
+        return warehouse.convert_type(
+            value, col_type, warehouse.python_type(col_type), "Array", "test_column"
+        )
 
-    assert converted == expected
+    none_last = to_db([{"k": 1}, None])
+    none_first = to_db([None, {"k": 1}])
+
+    # What an item becomes is the backend's business; that a None beside it does
+    # not change the answer is not.
+    assert none_last[1] is None
+    assert none_first[0] is None
+    assert none_last[0] == none_first[1]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6360,3 +6360,28 @@ def test_a_nullable_float_list_round_trips_whatever_the_order(
     )
 
     assert rows == [(expected,)]
+
+
+class DictItem(BaseModel):
+    n: int
+
+
+class DictItemHolder(BaseModel):
+    vals: list[dict[str, DictItem] | None]
+
+
+@pytest.mark.parametrize(
+    "vals",
+    [
+        pytest.param([{"a": DictItem(n=1)}, None], id="none-last"),
+        pytest.param([None, {"a": DictItem(n=1)}], id="none-first"),
+    ],
+)
+def test_models_inside_dict_items_convert_wherever_none_sits(test_session, vals):
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: DictItemHolder(vals=vals), output=DictItemHolder)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(vals,)]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6385,3 +6385,29 @@ def test_models_inside_dict_items_convert_wherever_none_sits(test_session, vals)
     )
 
     assert rows == [(vals,)]
+
+
+class OptionalChild(BaseModel):
+    x: int
+
+
+class OptionalChildHolder(BaseModel):
+    vals: list[OptionalChild | None]
+
+
+@pytest.mark.parametrize(
+    "vals",
+    [
+        pytest.param([OptionalChild(x=1), None], id="none-last"),
+        pytest.param([None, OptionalChild(x=2)], id="none-first"),
+        pytest.param([None, None], id="all-none"),
+    ],
+)
+def test_a_list_of_models_admitting_none_round_trips(test_session, vals):
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: OptionalChildHolder(vals=vals), output=OptionalChildHolder)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(vals,)]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6411,3 +6411,19 @@ def test_a_list_of_models_admitting_none_round_trips(test_session, vals):
     )
 
     assert rows == [(vals,)]
+
+
+class MixedUnionHolder(BaseModel):
+    vals: list[dict | list[dict] | None]
+
+
+def test_a_list_of_mixed_shapes_is_left_alone(test_session):
+    value = [None, [{"a": 1}], {"b": 2}]
+
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: MixedUnionHolder(vals=value), output=MixedUnionHolder)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(value,)]

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6313,3 +6313,50 @@ def test_tuple_of_models_stores_numpy_held_in_a_field(test_session):
             ),
         )
     ]
+
+
+class NullableInts(BaseModel):
+    vals: list[int | None]
+
+
+class NullableFloats(BaseModel):
+    vals: list[float | None]
+
+
+@pytest.mark.parametrize(
+    "vals",
+    [
+        pytest.param([1, None], id="none-last"),
+        pytest.param([None, 2], id="none-first"),
+        pytest.param([None, None], id="all-none"),
+        pytest.param([None, 2, None, 4], id="none-interleaved"),
+    ],
+)
+def test_a_nullable_int_list_round_trips_whatever_the_order(test_session, vals):
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: NullableInts(vals=vals), output=NullableInts)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(vals,)]
+
+
+@pytest.mark.parametrize(
+    "vals,expected",
+    [
+        pytest.param([1, None], [1.0, None], id="none-last"),
+        pytest.param([None, 2], [None, 2.0], id="none-first"),
+        pytest.param([None, None], [None, None], id="all-none"),
+    ],
+)
+def test_a_nullable_float_list_round_trips_whatever_the_order(
+    test_session, vals, expected
+):
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: NullableFloats(vals=vals), output=NullableFloats)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(expected,)]


### PR DESCRIPTION
`list[int | None]` fails to save when the first element is `None`:

```python
class Scores(dc.DataModel):
    vals: list[int | None]

chain.map(s=lambda: Scores(vals=[1, None]), output=Scores)   # ok
chain.map(s=lambda: Scores(vals=[None, 2]), output=Scores)   # UdfError
```

`convert_type` decided how to handle a whole array by looking at `val[0]`. A
leading `1` matched the item type, so the array was stored untouched and the
`None` rode along with it. A leading `None` did not match, so every element was
sent to a converter — and `None` has nothing to convert, so it raised.

Each element now answers for itself, and a `None` survives only where
`item_type.dc_nullable` says one belongs.

## What that changes

Read back after a save, `main` against this PR:

| `list[int \| None]` | main | here |
| --- | --- | --- |
| `[1, None]` | `[1, None]` | `[1, None]` |
| `[None, 2]` | `UdfError` | `[None, 2]` |
| `[None, None]` | `UdfError` | `[None, None]` |

| `list[float \| None]` | main | here |
| --- | --- | --- |
| `[1.0, None]` | `[1.0, nan]` | `[1.0, None]` |
| `[None, 2.0]` | `UdfError` | `[None, 2.0]` |

`nan` in that first row is the read side of the same bug: `TypeReadConverter.float`
maps `None` to `nan`, which is right for a float column and wrong for a nullable
element. Scalar `Optional[float]` already returns `None`, so arrays were the
outlier.

A model nested inside a dict item was converted in one order and not the other:

| `list[dict[str, Item] \| None]` | main | here |
| --- | --- | --- |
| `[{"a": Item(n=1)}, None]` | `TypeError: Object of type Item is not JSON serializable` | `[{'a': Item(n=1)}, None]` |
| `[None, {"a": Item(n=1)}]` | `[None, {'a': Item(n=1)}]` | `[None, {'a': Item(n=1)}]` |

And a `None` reached a **non-nullable** column unchecked, again depending on
where it sat:

```python
dc.read_values(x=[[1, None]], output={"x": list[int]}).to_values("x")
# main: [[1, None]]   -- stored into Array(Int64)
# here: UdfError

dc.read_values(x=[[None, 2]], output={"x": list[int]}).to_values("x")
# main: UdfError
# here: UdfError
```

## On disk

Only arrays that contain a `None` change, and only the order that was already
inconsistent with itself:

| `list[dict \| None]` | before | after |
| --- | --- | --- |
| `[{"k": 1}, None]` | `[{"k":1},null]` | unchanged |
| `[None, {"k": 1}]` | `["null","{\"k\":1}"]` | `[null,{"k":1}]` |

An array without a `None` takes exactly the path it took before, so nothing else
moves. Checked by writing twelve annotations with both versions and diffing the
stored column — `list[int]`, `list[str]`, `list[dict]`, `list[Model]`,
`list[list[int]]`, `tuple[int, ...]`, `tuple[str, ...]`, `tuple[Model, Model]`,
`tuple[int, int]` and the rest are byte-identical, and so are mixed arrays like
`({"k": 1}, 2)`.

Earlier revisions of this PR did not hold that line: one moved
`tuple[int, ...]` from `["1","2"]` to `[1,2]`, another moved `({"k": 1}, 2)` from
`[{"k":1},2]` to `[{"k":1},"2"]`. Both made `merge` on such a column return
nothing across old and new datasets, since the two hydrate the same but compare
as different in SQL.

Still unfixed here, exactly as on `main`: a model beside a plain value in an
array with no `None`, `({"a": Item(n=2)}, 1)`, is left raw and fails to write.
Same defect as the row above reached without a `None`; it belongs with the rest
of the mixed-array behaviour in #1968.

Converting every element costs about 10× more per array on a microbenchmark and
nothing measurable on a write: 4000 rows of 512-dim embeddings ran 2.83 s
against 2.81 s, JSON encoding and IO dominating. Arrays are also walked once to
find out whether a `None` is present, which the old code never did — that is
what keeps a stray `None` out of a non-nullable column.

## Left for [#1968](https://github.com/datachain-ai/datachain/issues/1968)

All of these are how `main` behaves today and are untouched here, because fixing
them changes the stored shape of arrays that already round-trip — which breaks
comparison between datasets written either side of the change. They are written
up under [*An array's stored shape is decided by one of its
elements*](https://github.com/datachain-ai/datachain/issues/1968):

- **A model beside a plain value is left raw.** `({"a": Item(n=2)}, 1)` raises
  `TypeError: Object of type Item is not JSON serializable`; reverse the order and
  it writes. Same defect as the `None` case fixed here, reached without a `None`.
- **Element order picks the layout of a mixed array.** `({"k": 1}, 2)` stores
  `[{'k': 1}, 2]`, `(2, {"k": 1})` stores `['2', '{"k":1}']`.
- **A tuple stores unlike the list of the same values.** `list[int]` stores
  `[1,2]`; `tuple[int, ...]` stores `["1","2"]`. This is what
  [#1963](https://github.com/datachain-ai/datachain/pull/1963) runs into.
- **Non-finite floats become `null`** in loosely typed fields — `dict` or `Any`,
  not `list[float]`.
- **A nested list cannot hold a `None` at the outer level.**
  `list[list[int] | None]` writes `[[1, 2], [3]]` but not `[None, [1, 2]]`: only a
  scalar item is made nullable, and an array has nowhere to keep the null. Since
  `list[Model | None]` resolves now, `list[list[Model | None] | None]` reaches the
  same wall, where it used to stop earlier for want of an inner type. Rejecting
  the annotation outright would take the working all-present case with it.
- **A root model element reads back as its bare value.** `list[RootModel[int]]`
  returns `[1, 2]`, not `[R(1), R(2)]`, because the reader rebuilds a model only
  from a mapping. The `Model | None` spelling is refused here rather than stored
  that way.

First of the steps found while reviewing #1963 — that PR's order-dependent
nullable failure is this same bug, reached through a different annotation.
