### PR TITLE
Add a job query type for running a file from git

### DIFF
--- a/src/datachain/data_storage/job.py
+++ b/src/datachain/data_storage/job.py
@@ -24,3 +24,4 @@ class JobStatus(int, Enum):
 class JobQueryType(int, Enum):
     PYTHON = 1
     SHELL = 2
+    FROM_GIT = 3

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -672,9 +672,7 @@ def create_job(  # noqa: PLR0913
     job_id = response.data.get("id")
     job_data = response.data
 
-    query_type_value = (
-        JobQueryType.PYTHON if query_type == "PYTHON" else JobQueryType.SHELL
-    )
+    query_type_value = JobQueryType[query_type]
     catalog.metastore.create_job(
         name=script_path,  # Use local script path, not Studio's query_name
         query=query,


### PR DESCRIPTION
Studio clones a repo into the job working directory already, but the code that actually runs still has to be pasted into the job, so it drifts from the repo.

The Studio side adds a `FROM_GIT` query type where `query` holds a repo-relative path instead of source, and the worker runs that file straight out of the clone. This enum has to land first: `JobFullResponse.from_model` in the backend and `SaaSJobFull.from_dict` in `datachain_saas` both do `JobQueryType(job.query_type)`, so a value of 3 raises `ValueError` until the member exists here.

Also fixes something the new member makes reachable. `create_job` mapped anything that was not `"PYTHON"` onto `SHELL` when mirroring a job into the local metastore:

```python
query_type_value = (
    JobQueryType.PYTHON if query_type == "PYTHON" else JobQueryType.SHELL
)
```

Fine with two members, quietly wrong with three, so it looks the member up by name now. The value is derived from the filename right there in `create_job`, so this was latent rather than biting anyone yet.

Nothing else in this repo reads the new member.