### PR TITLE
fix: keep None in an array wherever it sits

### DIFF
--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -149,25 +149,50 @@ class AbstractWarehouse(ABC, Serializable):
             if len(val) == 0:
                 return []
 
-            item_python_type = self.python_type(col_type.item_type)
-
-            if item_python_type is not list:
-                if isinstance(val[0], item_python_type):
-                    # SQLite ARRAY storage expects a list; tuples/sets must be
-                    # converted to lists even when element types already match.
-                    return list(val)
-                if item_python_type is float and isinstance(val[0], int):
-                    return [float(i) for i in val]
-
-            # Optimization: Reuse these values for each function call within the
-            # list comprehension.
+            item_type = col_type.item_type
+            item_python_type = self.python_type(item_type)
             item_type_info = (
-                col_type.item_type,
+                item_type,
                 item_python_type,
-                type(col_type.item_type).__name__,
+                type(item_type).__name__,
                 col_name,
             )
-            return [self.convert_type(i, *item_type_info) for i in val]
+
+            if type(None) not in map(type, val):
+                if item_python_type is not list:
+                    if isinstance(val[0], item_python_type):
+                        # SQLite ARRAY storage expects a list; tuples/sets must
+                        # be converted to lists even when element types already
+                        # match.
+                        return list(val)
+                    if item_python_type is float and isinstance(val[0], int):
+                        return [float(i) for i in val]
+                return [self.convert_type(i, *item_type_info) for i in val]
+
+            # Only an array actually holding a None gets here, so nothing else
+            # changes shape. Which element came first used to decide the whole
+            # array's fate, and a None cannot answer for the rest of it.
+            if item_python_type is dict:
+                objects = [i for i in val if i is not None]
+                if objects and all(isinstance(i, dict) for i in objects):
+                    # An array of JSON objects stays objects; normalizing each
+                    # one rather than passing it through is what reaches a model
+                    # nested inside.
+                    return [self._to_jsonable(i) for i in val]
+                return [self.convert_type(i, *item_type_info) for i in val]
+
+            # A JSON item carries its own null, and already did so in either
+            # order; only a type with no in-band null needs one kept back.
+            keep_none = (
+                getattr(item_type, "dc_nullable", False)
+                and type(item_type).__name__ != "JSON"
+            )
+            return [
+                i
+                if (keep_none and i is None) or isinstance(i, item_python_type)
+                else self.convert_type(i, *item_type_info)
+                for i in val
+            ]
 
         # Special use case with JSON type as we save it as string
         if col_python_type is dict or col_type_name == "JSON":

--- a/src/datachain/lib/convert/flatten.py
+++ b/src/datachain/lib/convert/flatten.py
@@ -85,10 +85,22 @@ def flatten_list(obj_list: list[BaseModel]) -> tuple:
 
 def _flatten_list_field(value: list) -> list:
     assert isinstance(value, list)
-    if value and ModelStore.is_pydantic(type(value[0])):
-        return [val.model_dump() for val in value]
-    if value and isinstance(value[0], list):
-        return [_flatten_list_field(v) for v in value]
+    # A None says nothing about what the list holds, so ask the first element
+    # that carries a type -- but one element cannot answer for the rest, so the
+    # others have to agree before a shape is assumed. Ordinary values settle it
+    # on the first element and never walk the list again.
+    first = next((val for val in value if val is not None), None)
+
+    if ModelStore.is_pydantic(type(first)):
+        if all(val is None or ModelStore.is_pydantic(type(val)) for val in value):
+            return [None if val is None else val.model_dump() for val in value]
+        return value
+
+    if isinstance(first, list) and all(
+        val is None or isinstance(val, list) for val in value
+    ):
+        return [None if val is None else _flatten_list_field(val) for val in value]
+
     return value
 
 

--- a/src/datachain/sql/types.py
+++ b/src/datachain/sql/types.py
@@ -561,6 +561,13 @@ class TypeReadConverter:
     def array(self, value, item_type, dialect):
         if value is None or item_type is None:
             return value
+        if getattr(item_type, "dc_nullable", False):
+            # A nullable element keeps its None, the way a nullable column does;
+            # float() would otherwise turn it into nan.
+            return [
+                None if x is None else item_type.on_read_convert(x, dialect)
+                for x in value
+            ]
         return [item_type.on_read_convert(x, dialect) for x in value]
 
     def json(self, value):

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -19,6 +19,8 @@ from datachain.sql.types import (
     Float32,
     Float64,
     Int,
+    Int64,
+    SQLType,
     String,
 )
 from tests.utils import (
@@ -355,3 +357,99 @@ def test_a_model_refuses_numpy_that_would_be_stored_as_null(test_session, make):
 
     with pytest.raises(ValueError, match="writes NaN and infinities as null"):
         _model_payload(warehouse, make())
+
+
+class NestedItem(BaseModel):
+    n: int
+
+
+@pytest.mark.parametrize(
+    "value,item_type,expected",
+    [
+        pytest.param((1, None), Int64, [1, None], id="int-none-last"),
+        pytest.param((None, 2), Int64, [None, 2], id="int-none-first"),
+        pytest.param((None, None), Int64, [None, None], id="int-all-none"),
+        pytest.param([1, None], Float, [1.0, None], id="float-none-last"),
+        pytest.param([None, 2], Float, [None, 2.0], id="float-none-first"),
+        pytest.param(["a", None], String, ["a", None], id="str-none-last"),
+        pytest.param([None, "b"], String, [None, "b"], id="str-none-first"),
+    ],
+)
+def test_convert_type_keeps_none_wherever_it_sits_in_an_array(
+    test_session, value, item_type, expected
+):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(SQLType.as_nullable(item_type))
+
+    converted = warehouse.convert_type(
+        value,
+        col_type,
+        warehouse.python_type(col_type),
+        "Array",
+        "test_column",
+    )
+
+    assert converted == expected
+
+
+def test_convert_type_stores_a_json_array_the_same_wherever_none_sits(test_session):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(JSON())
+
+    def to_db(value):
+        return warehouse.convert_type(
+            value, col_type, warehouse.python_type(col_type), "Array", "test_column"
+        )
+
+    # What an item becomes is the backend's business; that its neighbours do not
+    # change the answer is not.
+    assert to_db([{"k": 1}, None]) == list(reversed(to_db([None, {"k": 1}])))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param([None, 2], id="none-first"),
+        pytest.param([1, None], id="none-last"),
+    ],
+)
+def test_convert_type_refuses_none_in_a_non_nullable_array(test_session, value):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(Int64)
+
+    with pytest.raises(ValueError, match="incompatible"):
+        warehouse.convert_type(
+            value, col_type, warehouse.python_type(col_type), "Array", "test_column"
+        )
+
+
+def test_convert_type_json_encodes_an_all_none_array(test_session):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(SQLType.as_nullable(JSON()))
+
+    converted = warehouse.convert_type(
+        (None, None), col_type, warehouse.python_type(col_type), "Array", "test_column"
+    )
+
+    # An array with no object in it is not an array of objects; each None stays
+    # whatever JSON writes for one, as it did before.
+    assert converted == [json.dumps(None)] * 2
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param((None, {"a": NestedItem(n=2)}), id="none-first"),
+        pytest.param(({"a": NestedItem(n=2)}, None), id="none-last"),
+    ],
+)
+def test_convert_type_leaves_no_model_in_a_json_array_holding_none(test_session, value):
+    warehouse = test_session.catalog.warehouse
+    col_type = Array(JSON())
+
+    converted = warehouse.convert_type(
+        value, col_type, warehouse.python_type(col_type), "Array", "test_column"
+    )
+
+    # Whatever shape the backend asks for, nothing unserializable may survive.
+    json.dumps(converted)

--- a/tests/unit/lib/test_datachain.py
+++ b/tests/unit/lib/test_datachain.py
@@ -6313,3 +6313,91 @@ def test_tuple_of_models_stores_numpy_held_in_a_field(test_session):
             ),
         )
     ]
+
+
+class NullableInts(BaseModel):
+    vals: list[int | None]
+
+
+class NullableFloats(BaseModel):
+    vals: list[float | None]
+
+
+@pytest.mark.parametrize(
+    "vals",
+    [
+        pytest.param([1, None], id="none-last"),
+        pytest.param([None, 2], id="none-first"),
+        pytest.param([None, None], id="all-none"),
+        pytest.param([None, 2, None, 4], id="none-interleaved"),
+    ],
+)
+def test_a_nullable_int_list_round_trips_whatever_the_order(test_session, vals):
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: NullableInts(vals=vals), output=NullableInts)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(vals,)]
+
+
+@pytest.mark.parametrize(
+    "vals,expected",
+    [
+        pytest.param([1, None], [1.0, None], id="none-last"),
+        pytest.param([None, 2], [None, 2.0], id="none-first"),
+        pytest.param([None, None], [None, None], id="all-none"),
+    ],
+)
+def test_a_nullable_float_list_round_trips_whatever_the_order(
+    test_session, vals, expected
+):
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: NullableFloats(vals=vals), output=NullableFloats)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(expected,)]
+
+
+class DictItem(BaseModel):
+    n: int
+
+
+class DictItemHolder(BaseModel):
+    vals: list[dict[str, DictItem] | None]
+
+
+@pytest.mark.parametrize(
+    "vals",
+    [
+        pytest.param([{"a": DictItem(n=1)}, None], id="none-last"),
+        pytest.param([None, {"a": DictItem(n=1)}], id="none-first"),
+    ],
+)
+def test_models_inside_dict_items_convert_wherever_none_sits(test_session, vals):
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: DictItemHolder(vals=vals), output=DictItemHolder)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(vals,)]
+
+
+class MixedUnionHolder(BaseModel):
+    vals: list[dict | list[dict] | None]
+
+
+def test_a_list_of_mixed_shapes_is_left_alone(test_session):
+    value = [None, [{"a": 1}], {"b": 2}]
+
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: MixedUnionHolder(vals=value), output=MixedUnionHolder)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(value,)]


### PR DESCRIPTION
`list[int | None]` fails to save when the first element is `None`:

```python
class Scores(dc.DataModel):
    vals: list[int | None]

chain.map(s=lambda: Scores(vals=[1, None]), output=Scores)   # ok
chain.map(s=lambda: Scores(vals=[None, 2]), output=Scores)   # UdfError
```

Three places decided how to treat a whole array by looking at one element of it.

`convert_type` read `val[0]`: a leading `1` matched the item type, so the array
was stored untouched and the `None` rode along; a leading `None` did not match,
so every element went to a converter — and `None` has nothing to convert.

`flatten` read `value[0]` the same way: a leading model meant `model_dump()` on
every element including the `None`s, a leading `None` meant the models were left
raw, and neither could answer for a list of mixed shapes.

`TypeReadConverter.float` maps `None` to `nan`, which is right for a bare float
column and wrong for a nullable element — without that, these arrays would newly
save and then read back `[1.0, nan]`. Scalar `Optional[float]` already returns
`None`; arrays were the outlier.

## What that changes

| `list[int \| None]` | main | here |
| --- | --- | --- |
| `[1, None]` | `[1, None]` | `[1, None]` |
| `[None, 2]` | `UdfError` | `[None, 2]` |
| `[None, None]` | `UdfError` | `[None, None]` |

| `list[float \| None]` | main | here |
| --- | --- | --- |
| `[1.0, None]` | `[1.0, nan]` | `[1.0, None]` |
| `[None, 2.0]` | `UdfError` | `[None, 2.0]` |

A model nested inside a dict item was converted in one order and not the other:

| `list[dict[str, Item] \| None]` | main | here |
| --- | --- | --- |
| `[{"a": Item(n=1)}, None]` | `TypeError: Object of type Item is not JSON serializable` | `[{'a': Item(n=1)}, None]` |
| `[None, {"a": Item(n=1)}]` | works | works |

And a `None` reached a **non-nullable** column unchecked, again depending on
where it sat:

```python
dc.read_values(x=[[1, None]], output={"x": list[int]}).to_values("x")
# main: [[1, None]]   -- stored into Array(Int64)
# here: UdfError
```

## On disk

Only arrays that contain a `None` change, and of those only the order that was
already inconsistent with itself:

| `list[dict \| None]` | before | after |
| --- | --- | --- |
| `[{"k": 1}, None]` | `[{"k":1},null]` | unchanged |
| `[None, {"k": 1}]` | `["null","{\"k\":1}"]` | `[null,{"k":1}]` |

Arrays without a `None` take exactly the path they took before — `list[int]`,
`list[str]`, `list[dict]`, `list[Model]`, `list[list[int]]`, `tuple[int, ...]`,
`tuple[str, ...]`, `tuple[Model, Model]`, `tuple[int, int]`, and mixed arrays
like `({"k": 1}, 2)` are byte-identical, checked by writing each with both
versions and diffing the stored column.

## Left for [#1968](https://github.com/datachain-ai/datachain/issues/1968)

How `main` behaves today, untouched here, because fixing them changes the stored
shape of arrays that already round-trip:

- **A model beside a plain value is left raw.** `({"a": Item(n=2)}, 1)` raises;
  reverse the order and it writes.
- **Element order picks a mixed array's layout.** `({"k": 1}, 2)` stores
  `[{'k': 1}, 2]`, `(2, {"k": 1})` stores `['2', '{"k":1}']`.
- **A tuple stores unlike the list of the same values.** `list[int]` stores
  `[1,2]`; `tuple[int, ...]` stores `["1","2"]` — what
  [#1963](https://github.com/datachain-ai/datachain/pull/1963) runs into.
- **Non-finite floats become `null`** in `dict` or `Any` fields.
- **A nested list cannot hold a `None` at the outer level.**
  `list[list[int] | None]` writes `[[1, 2], [3]]` but not `[None, [1, 2]]`.

## Stack

1. **this PR** — `None` anywhere in an array
2. #1976 — the spellings of a nullable element type
3. #1977 — a list of models that admits a `None`

Replaces #1970, which carried all three at once.
