### PR TITLE
fix: recognize every spelling of a nullable array element

### DIFF
--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -11,7 +11,6 @@ from datachain.lib.data_model import (
     NULLABLE_SCALARS,
     is_mapping_annotation,
     is_sequence_annotation,
-    unwrap_optional,
 )
 from datachain.lib.model_store import ModelStore
 from datachain.sql.types import (
@@ -191,12 +190,58 @@ def _list_to_array(typ, args):
         return Array(JSON())
 
     list_type = list_of_args_to_type(args)
-    # Optional[scalar] elements map to a nullable Array element so None survives
-    # (ClickHouse: Array(Nullable(T))).
-    inner, is_optional = unwrap_optional(args0)
-    if is_optional and inner in NULLABLE_SCALARS:
-        list_type = SQLType.as_nullable(list_type)
+
+    # An element admitting None maps to a nullable Array element so the None
+    # survives (ClickHouse: Array(Nullable(T))). A fixed tuple keeps every slot
+    # in the one column, so any slot admitting one decides it.
+    if any(_admits_none(arg) for arg in args if arg is not Ellipsis):
+        if _takes_null(list_type):
+            list_type = SQLType.as_nullable(list_type)
+        else:
+            # An Array element cannot be made nullable -- ClickHouse has no
+            # Nullable(Array) -- so an optional collection is carried as a JSON
+            # document, which can be.
+            list_type = SQLType.as_nullable(JSON())
     return Array(list_type)
+
+
+def _admits_none(annotation: Any) -> bool:
+    """Whether this annotation permits None, however the None is spelled.
+
+    Structural on purpose. Asking Pydantic to validate a None would run whatever
+    validators the field declares -- a BeforeValidator rejecting None would then
+    fail the schema for a column of ordinary ints -- and a coercing one would
+    answer for its own behaviour rather than for the declared type.
+    """
+    if annotation is None or annotation is type(None):
+        return True
+
+    origin = get_origin(annotation)
+    if origin in (Literal, LiteralEx):
+        return any(value is None for value in get_args(annotation))
+    if origin is Annotated:
+        return _admits_none(get_args(annotation)[0])
+    if origin in (Union, UnionType):
+        return any(_admits_none(arm) for arm in get_args(annotation))
+    return False
+
+
+def _takes_null(sql_type: Any) -> bool:
+    """Whether a NULL can sit in this column type.
+
+    By subclass, since the scalar may have been subclassed. An Array has nowhere
+    to keep one; a JSON element does, the array around it holding the NULL
+    rather than the document.
+    """
+    sql_cls = sql_type if isinstance(sql_type, type) else type(sql_type)
+    if issubclass(sql_cls, JSON):
+        return True
+    for scalar in NULLABLE_SCALARS:
+        nullable = python_to_sql(scalar)
+        nullable_cls = nullable if isinstance(nullable, type) else type(nullable)
+        if issubclass(sql_cls, nullable_cls):
+            return True
+    return False
 
 
 def list_of_args_to_type(args) -> SQLType:

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -197,10 +197,13 @@ def _list_to_array(typ, args):
     if any(_admits_none(arg) for arg in args if arg is not Ellipsis):
         if _takes_null(list_type):
             list_type = SQLType.as_nullable(list_type)
-        else:
+        elif _survives_json(list_type):
             # An Array element cannot be made nullable -- ClickHouse has no
             # Nullable(Array) -- so an optional collection is carried as a JSON
-            # document, which can be.
+            # document, which can be. Only where its leaves read back the same
+            # from JSON: a datetime would come back as the ISO string it was
+            # written as, so that array keeps its typed form and its None stays
+            # unwritable, as before.
             list_type = SQLType.as_nullable(JSON())
     return Array(list_type)
 
@@ -224,6 +227,20 @@ def _admits_none(annotation: Any) -> bool:
     if origin in (Union, UnionType):
         return any(_admits_none(arm) for arm in get_args(annotation))
     return False
+
+
+def _survives_json(sql_type: Any) -> bool:
+    """Whether a value of this type reads back unchanged from a JSON document.
+
+    Numbers, booleans, strings and JSON itself do; a datetime or bytes is
+    written as a string and would be read back as one.
+    """
+    if isinstance(sql_type, Array):
+        return _survives_json(sql_type.item_type)
+    instance = sql_type() if isinstance(sql_type, type) else sql_type
+    if isinstance(instance, JSON):
+        return True
+    return instance.python_type in (int, float, bool, str)
 
 
 def _takes_null(sql_type: Any) -> bool:

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -534,3 +534,16 @@ def test_an_optional_nested_collection_round_trips(test_session, vals):
     )
 
     assert rows == [(vals,)]
+
+
+def test_an_optional_nested_array_keeps_a_typed_leaf():
+    # The JSON fallback for an optional collection only applies where the leaves
+    # read back the same from JSON; a datetime would come back as its ISO string.
+    assert python_to_sql(list[list[datetime] | None]).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "Array", "item_type": {"type": "DateTime"}},
+    }
+    assert python_to_sql(list[list[int] | None]).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "JSON", "dc_nullable": True},
+    }

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -1,15 +1,17 @@
 import uuid
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Annotated, Any, Literal
 
 import numpy as np
 import pandas as pd
 import pytest
 import ujson as json
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, BeforeValidator, ConfigDict
 
+import datachain as dc
 from datachain import json as dcjson
+from datachain.lib.convert.python_to_sql import python_to_sql
 from datachain.sql.types import (
     JSON,
     Array,
@@ -423,3 +425,112 @@ def test_convert_type_leaves_no_model_in_a_json_array_holding_none(test_session,
 
     # Whatever shape the backend asks for, nothing unserializable may survive.
     json.dumps(converted)
+
+
+class SubclassedInt(Int64):
+    pass
+
+
+@pytest.mark.parametrize(
+    "annotation,value",
+    [
+        pytest.param(list[int | None], [1, None], id="plain-int"),
+        pytest.param(list[int | None], [None, 2], id="plain-int-none-first"),
+        pytest.param(
+            list[Annotated[int, "meta"] | None], [1, None], id="annotated-int"
+        ),
+        pytest.param(list[Literal["a", "b"] | None], ["a", None], id="literal-str"),
+        pytest.param(
+            list[Literal["a", "b"] | None], [None, "b"], id="literal-str-none-first"
+        ),
+        pytest.param(
+            list[Annotated[int | None, "meta"]], [1, None], id="optional-in-annotated"
+        ),
+        pytest.param(
+            list[Annotated[int | None, "meta"]],
+            [None, 2],
+            id="optional-in-annotated-none-first",
+        ),
+        pytest.param(
+            list[Annotated[Literal["a", None], "meta"]],  # noqa: PYI061
+            ["a", None],
+            id="none-among-literal-values",
+        ),
+        pytest.param(list[SubclassedInt | None], [1, None], id="subclassed-sql-type"),
+        pytest.param(
+            list[Annotated[SubclassedInt | None, "meta"]],
+            [1, None],
+            id="subclassed-sql-type-in-annotated",
+        ),
+        pytest.param(
+            list[str | Literal[None]],  # noqa: PYI061
+            ["a", None],
+            id="literal-none-in-a-union",
+        ),
+        pytest.param(
+            tuple[str, Literal[None]],  # noqa: PYI061
+            ("a", None),
+            id="null-only-literal-slot",
+        ),
+        pytest.param(
+            list[Literal[None]],  # noqa: PYI061
+            [None],
+            id="null-only-literal-item",
+        ),
+        pytest.param(tuple[int, int | None], (1, None), id="second-tuple-slot"),
+        pytest.param(tuple[int | None, int], (None, 1), id="first-tuple-slot"),
+    ],
+)
+def test_convert_type_keeps_none_for_a_wrapped_nullable_scalar(
+    test_session, annotation, value
+):
+    warehouse = test_session.catalog.warehouse
+    col_type = python_to_sql(annotation)
+
+    converted = warehouse.convert_type(
+        value, col_type, warehouse.python_type(col_type), "Array", "test_column"
+    )
+
+    assert converted == list(value)
+
+
+def _rejects_none(value):
+    if value is None:
+        raise TypeError("this field does not take None")
+    return int(value)
+
+
+def test_python_to_sql_does_not_run_a_field_validator():
+    # Deciding nullability by validating a None would run whatever the field
+    # declares, and fail a column of ordinary ints on a validator's own rules.
+    annotation = list[Annotated[int, BeforeValidator(_rejects_none)]]
+
+    assert python_to_sql(annotation).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "Int64"},
+    }
+
+
+class NestedOptional(BaseModel):
+    vals: list[list[int] | None]
+
+
+@pytest.mark.parametrize(
+    "vals",
+    [
+        pytest.param([[1, 2], None], id="none-last"),
+        pytest.param([None, [1, 2]], id="none-first"),
+        pytest.param([None, None], id="all-none"),
+        pytest.param([[1, 2], []], id="empty-is-not-none"),
+    ],
+)
+def test_an_optional_nested_collection_round_trips(test_session, vals):
+    # An Array element cannot be nullable, so the element is carried as JSON --
+    # which keeps a None distinct from an empty collection.
+    rows = (
+        dc.read_values(i=[1], session=test_session)
+        .map(h=lambda: NestedOptional(vals=vals), output=NestedOptional)
+        .to_list("h.vals")
+    )
+
+    assert rows == [(vals,)]


### PR DESCRIPTION
Stacked on #1978.

An array's element type was called nullable by testing the annotation against
`(int, float, str, bool, bytes, datetime)` — which only the plainest spelling
passes. All of these resolved to a **non-nullable** item and then refused a
`None` that Pydantic had accepted into the field:

```python
list[Annotated[int, "meta"] | None]
list[Annotated[int | None, "meta"]]
list[Literal["a", "b"] | None]
list[Annotated[Literal["a", None], "meta"]]
list[str | Literal[None]]
list[Literal[None]]
list[SubclassedInt | None]          # class SubclassedInt(Int64)
tuple[str, Literal[None]]
tuple[int, int | None]
```

Every one already resolves to the right item type — `Int64`, `String`,
`SubclassedInt` — they simply were not marked nullable.

## Reading the annotation

A `None` counts wherever it is spelled: among a `Literal`'s values, inside
`Annotated`, as a union arm, at any nesting. Eleven lines, and **deliberately
structural** — asking Pydantic to validate a `None` would run whatever validators
the field declares, so a `BeforeValidator` that rejects `None` would fail the
schema for a column of ordinary ints, and a coercing one would answer for its own
behaviour rather than for the declared type.

Two smaller corrections: only `args[0]` was asked, though a fixed tuple keeps
every slot in the one column; and nullability is read from the **resolved column
type** rather than the annotation, so a user's `Int64` subclass is recognized as
the scalar it is.

## Optional collections

An `Array` element cannot be made nullable — ClickHouse has no
`Nullable(Array)` — so `list[list[int] | None]` has nowhere to keep the `None`.
It is carried as `Array(Nullable(JSON))` instead, which can, and which keeps a
`None` distinct from an empty collection:

| value | main | here |
| --- | --- | --- |
| `[[1, 2], None]` | `AssertionError` | `[[1, 2], None]` |
| `[None, [1, 2]]` | `UdfError` | `[None, [1, 2]]` |
| `[None, None]` | `UdfError` | `[None, None]` |
| `[[1, 2], []]` | works | works |

## Not covered

Some spellings fail at **resolution**, before nullability is ever consulted, and
that is unchanged here: `list[int | Literal[None]]`,
`list[Annotated[str, "meta"] | Literal[None]]`, `list[None]`,
`list[type(None)]`. Resolution belongs to
[#1968](https://github.com/datachain-ai/datachain/issues/1968); this PR makes
nullable *recognizable*, not every annotation *resolvable*.

## Stack

1. #1963 — variadic tuple element type, physical fingerprint
2. #1978 — canonical array conversion, codec version
3. **this PR** — nullable element spellings, nullable-collection fallback
4. #1977 — optional model elements
