### PR TITLE
fix: store a list of models that admits a None

### DIFF
--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -4,7 +4,7 @@ from enum import Enum
 from types import UnionType
 from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel
 from typing_extensions import Literal as LiteralEx
 
 from datachain.lib.data_model import (
@@ -185,9 +185,20 @@ def _list_to_array(typ, args):
         args = args[:1]
     if not args:
         raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
-    args0 = args[0]
-    if ModelStore.is_pydantic(args0):
-        return Array(JSON())
+    # A model element is JSON whether or not it admits a None: is_chain_type
+    # accepts list[Model | None], and the union arm is all that hid the model.
+    # A fixed tuple keeps every slot in the one column, so every slot is asked --
+    # answering from the first would let a slot through that cannot be read back
+    # as a model.
+    slots = [arg for arg in args if arg is not Ellipsis]
+    if slots and all(
+        ModelStore.is_pydantic(slot) or _optional_model(slot) is not None
+        for slot in slots
+    ):
+        item: SQLType = JSON()
+        if any(_admits_none(slot) for slot in slots):
+            item = SQLType.as_nullable(item)
+        return Array(item)
 
     list_type = list_of_args_to_type(args)
 
@@ -206,6 +217,39 @@ def _list_to_array(typ, args):
             # unwritable, as before.
             list_type = SQLType.as_nullable(JSON())
     return Array(list_type)
+
+
+def _optional_model(annotation: Any) -> Any:
+    """The model behind ``Model | None``, or None if that is not the shape.
+
+    Deliberately shallow: only a bare None, because the reader rebuilds a nested
+    model from Optional[Model] and not from Model | Literal[None], which would be
+    stored and handed back as plain dicts.
+    """
+    if get_origin(annotation) not in (Union, UnionType):
+        return None
+
+    arms = [arm for arm in get_args(annotation) if arm is not type(None)]
+    if len(arms) != 1 or not ModelStore.is_pydantic(arms[0]):
+        return None
+    if not _serializes_as_a_mapping(arms[0]):
+        return None
+    return arms[0]
+
+
+def _serializes_as_a_mapping(model: Any) -> bool:
+    """Whether this model is read back from a mapping, as a stored one is.
+
+    A root model dumps to whatever it wraps, and a model_serializer may return
+    anything at all; the reader rebuilds a nested model only from a mapping, so
+    either would be stored and then handed back as something else.
+    """
+    if not isinstance(model, type):
+        return False
+    if issubclass(model, RootModel):
+        return False
+    decorators = getattr(model, "__pydantic_decorators__", None)
+    return not (decorators and decorators.model_serializers)
 
 
 def _admits_none(annotation: Any) -> bool:

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -191,10 +191,17 @@ def _list_to_array(typ, args):
     # answering from the first would let a slot through that cannot be read back
     # as a model.
     slots = [arg for arg in args if arg is not Ellipsis]
-    if slots and all(
-        ModelStore.is_pydantic(slot) or _optional_model(slot) is not None
-        for slot in slots
-    ):
+
+    if slots and any(_holds_a_model(slot) for slot in slots):
+        if not all(_holds_a_model(slot) for slot in slots):
+            # A model beside something that is not one: no single element type
+            # between them, so the array carries JSON. Asked of every slot, or
+            # tuple[Model, int] would raise where tuple[int, Model] did not.
+            return Array(JSON())
+        if any(_model_element(slot) is None for slot in slots):
+            # Every slot is a model, but one of them is not read back as one.
+            raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
+
         item: SQLType = JSON()
         if any(_admits_none(slot) for slot in slots):
             item = SQLType.as_nullable(item)
@@ -217,6 +224,35 @@ def _list_to_array(typ, args):
             # unwritable, as before.
             list_type = SQLType.as_nullable(JSON())
     return Array(list_type)
+
+
+def _holds_a_model(annotation: Any) -> bool:
+    """Whether this element is a model, or an Optional holding one.
+
+    Separate from whether the model can be read back: a slot that holds one it
+    cannot rebuild has to refuse the annotation, while a slot holding no model
+    at all just means the array carries JSON.
+    """
+    if get_origin(annotation) is Annotated:
+        return _holds_a_model(get_args(annotation)[0])
+    if ModelStore.is_pydantic(annotation):
+        return True
+    if get_origin(annotation) not in (Union, UnionType):
+        return False
+    arms = [arm for arm in get_args(annotation) if arm is not type(None)]
+    return len(arms) == 1 and _holds_a_model(arms[0])
+
+
+def _model_element(annotation: Any) -> Any:
+    """The model this element stores as, or None if it does not store as one.
+
+    Required and optional slots answer to the same contract: a model the reader
+    can rebuild. Asking it only of the optional ones would let
+    tuple[A | None, ScalarDump] through on the strength of its first slot.
+    """
+    if ModelStore.is_pydantic(annotation) and _serializes_as_a_mapping(annotation):
+        return annotation
+    return _optional_model(annotation)
 
 
 def _optional_model(annotation: Any) -> Any:

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -193,13 +193,11 @@ def _list_to_array(typ, args):
     slots = [arg for arg in args if arg is not Ellipsis]
 
     if slots and any(_holds_a_model(slot) for slot in slots):
-        if not all(_holds_a_model(slot) for slot in slots):
-            # A model beside something that is not one: no single element type
-            # between them, so the array carries JSON. Asked of every slot, or
-            # tuple[Model, int] would raise where tuple[int, Model] did not.
-            return Array(JSON())
-        if any(_model_element(slot) is None for slot in slots):
-            # Every slot is a model, but one of them is not read back as one.
+        # Any model among the slots makes the element JSON: there is no single
+        # column type between a model and anything else. Every slot holding one
+        # is checked first, whether or not the others do -- returning early on
+        # the mixed case would let an unreadable model in beside an int.
+        if any(_holds_a_model(slot) and _model_element(slot) is None for slot in slots):
             raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
 
         item: SQLType = JSON()

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -3,9 +3,10 @@ from collections.abc import Mapping
 from datetime import datetime
 from enum import Enum
 from types import UnionType
-from typing import Annotated, Any, Literal, Union, get_args, get_origin
+from typing import Annotated, Any, Literal, Union, get_args, get_origin, get_type_hints
 
 from pydantic import BaseModel, RootModel
+from pydantic_core import PydanticUndefined
 from typing_extensions import Literal as LiteralEx
 
 from datachain.lib.data_model import (
@@ -202,16 +203,16 @@ def _list_to_array(typ, args):
             raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
 
         for slot in slots:
-            if _holds_a_model(slot):
+            if _holds_a_model(slot) or _is_null_only(slot):
                 continue
             # JSON is the element type here, so a slot that is refused outright
             # must not be swept into it, and one that maps to nothing is not
             # storable either.
             slot_type = python_to_sql(slot)
-            slot_cls = slot_type if isinstance(slot_type, type) else type(slot_type)
-            if issubclass(slot_cls, (String, Binary)):
-                # A JSON element is read back as a document, and a bare string
-                # is not one -- "hello" comes back as a JSONDecodeError.
+            if not _reads_back_as_a_json_document(slot_type):
+                # A JSON element is read back as a document. A bare string is
+                # not one, and neither is the string a datetime or bytes is
+                # written as -- each comes back as a JSONDecodeError.
                 raise UnstorableTypeError(
                     f"Cannot store {slot!r} as a JSON element beside a model"
                 )
@@ -238,6 +239,25 @@ def _list_to_array(typ, args):
             # unwritable, as before.
             list_type = SQLType.as_nullable(JSON())
     return Array(list_type)
+
+
+def _is_null_only(annotation: Any) -> bool:
+    """Whether this annotation admits nothing but None -- Literal[None]."""
+    if get_origin(annotation) not in (Literal, LiteralEx):
+        return False
+    values = get_args(annotation)
+    return bool(values) and all(value is None for value in values)
+
+
+def _reads_back_as_a_json_document(sql_type: Any) -> bool:
+    """Whether a value of this column type is itself a valid JSON document.
+
+    Numbers, booleans and JSON are; anything written as a bare string is not.
+    """
+    instance = sql_type() if isinstance(sql_type, type) else sql_type
+    if isinstance(instance, JSON):
+        return True
+    return instance.python_type in (int, float, bool)
 
 
 def _holds_a_model(annotation: Any) -> bool:
@@ -310,8 +330,16 @@ def _returns_a_mapping(serializer: Any) -> bool:
     runs. One that declares nothing could return anything, so it is not taken on
     trust.
     """
-    func = getattr(serializer, "func", serializer)
-    annotation = getattr(func, "__annotations__", {}).get("return")
+    info = getattr(serializer, "info", None)
+    annotation = getattr(info, "return_type", PydanticUndefined)
+    if annotation is PydanticUndefined:
+        # Not given to the decorator, so read from the function -- resolved, as
+        # `from __future__ import annotations` leaves it a string otherwise.
+        func = getattr(serializer, "func", serializer)
+        try:
+            annotation = get_type_hints(func).get("return")
+        except (NameError, TypeError):
+            return False
     if annotation is None:
         return False
     origin = get_origin(annotation) or annotation

--- a/src/datachain/lib/convert/python_to_sql.py
+++ b/src/datachain/lib/convert/python_to_sql.py
@@ -1,4 +1,5 @@
 import inspect
+from collections.abc import Mapping
 from datetime import datetime
 from enum import Enum
 from types import UnionType
@@ -200,6 +201,21 @@ def _list_to_array(typ, args):
         if any(_holds_a_model(slot) and _model_element(slot) is None for slot in slots):
             raise TypeError(f"Cannot resolve type '{typ}' for flattening features")
 
+        for slot in slots:
+            if _holds_a_model(slot):
+                continue
+            # JSON is the element type here, so a slot that is refused outright
+            # must not be swept into it, and one that maps to nothing is not
+            # storable either.
+            slot_type = python_to_sql(slot)
+            slot_cls = slot_type if isinstance(slot_type, type) else type(slot_type)
+            if issubclass(slot_cls, (String, Binary)):
+                # A JSON element is read back as a document, and a bare string
+                # is not one -- "hello" comes back as a JSONDecodeError.
+                raise UnstorableTypeError(
+                    f"Cannot store {slot!r} as a JSON element beside a model"
+                )
+
         item: SQLType = JSON()
         if any(_admits_none(slot) for slot in slots):
             item = SQLType.as_nullable(item)
@@ -283,7 +299,23 @@ def _serializes_as_a_mapping(model: Any) -> bool:
     if issubclass(model, RootModel):
         return False
     decorators = getattr(model, "__pydantic_decorators__", None)
-    return not (decorators and decorators.model_serializers)
+    serializers = getattr(decorators, "model_serializers", None) or {}
+    return all(_returns_a_mapping(entry) for entry in serializers.values())
+
+
+def _returns_a_mapping(serializer: Any) -> bool:
+    """Whether a model_serializer is declared to return a mapping.
+
+    Read from its return annotation, the only thing said about it before it
+    runs. One that declares nothing could return anything, so it is not taken on
+    trust.
+    """
+    func = getattr(serializer, "func", serializer)
+    annotation = getattr(func, "__annotations__", {}).get("return")
+    if annotation is None:
+        return False
+    origin = get_origin(annotation) or annotation
+    return isinstance(origin, type) and issubclass(origin, Mapping)
 
 
 def _admits_none(annotation: Any) -> bool:

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -7,7 +7,13 @@ import numpy as np
 import pandas as pd
 import pytest
 import ujson as json
-from pydantic import BaseModel, BeforeValidator, ConfigDict
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    RootModel,
+    model_serializer,
+)
 
 import datachain as dc
 from datachain import json as dcjson
@@ -547,3 +553,63 @@ def test_an_optional_nested_array_keeps_a_typed_leaf():
         "type": "Array",
         "item_type": {"type": "JSON", "dc_nullable": True},
     }
+
+
+class SlotA(BaseModel):
+    x: int
+
+
+class SlotB(BaseModel):
+    y: int
+
+
+def test_python_to_sql_refuses_a_tuple_slot_that_reads_back_wrong():
+    # Every slot of a fixed tuple shares the column, so one that cannot be read
+    # back as a model has to refuse the whole annotation rather than be stored
+    # and handed back as a plain dict.
+    with pytest.raises(TypeError):
+        python_to_sql(tuple[SlotA | None, Annotated[SlotB, "meta"] | None])
+
+    assert python_to_sql(tuple[SlotA | None, SlotB | None]).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "JSON", "dc_nullable": True},
+    }
+
+
+class RootInt(RootModel[int]):
+    pass
+
+
+def test_python_to_sql_refuses_an_optional_root_model_element():
+    # A root model dumps to its bare value, which the reader cannot rebuild into
+    # a model, so it must not be admitted by the optional-model shortcut.
+    with pytest.raises(TypeError):
+        python_to_sql(list[RootInt | None])
+
+
+class ScalarDump(BaseModel):
+    x: int
+
+    @model_serializer
+    def _dump(self):
+        return self.x
+
+
+def test_python_to_sql_checks_every_tuple_slot_for_a_model():
+    # Answering from the first slot let the rest through unchecked: a nullable
+    # second slot lost its dc_nullable, and one that cannot be read back as a
+    # model was accepted.
+    assert python_to_sql(tuple[SlotA, SlotB | None]).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "JSON", "dc_nullable": True},
+    }
+
+    with pytest.raises(TypeError):
+        python_to_sql(tuple[SlotA, RootInt | None])
+
+
+def test_python_to_sql_refuses_a_model_that_does_not_dump_to_a_mapping():
+    # The reader rebuilds a nested model from a mapping, so a model_serializer
+    # returning something else would be stored and handed back as that instead.
+    with pytest.raises(TypeError):
+        python_to_sql(list[ScalarDump | None])

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -657,3 +657,36 @@ def test_a_model_beside_a_scalar_is_still_held_to_the_contract():
     # the reader cannot rebuild, whatever sits next to it.
     with pytest.raises(TypeError):
         python_to_sql(tuple[ScalarDump | None, int])
+
+
+class MappingDump(BaseModel):
+    x: int
+
+    @model_serializer
+    def _dump(self) -> dict[str, int]:
+        return {"x": self.x}
+
+
+def test_a_serializer_returning_a_mapping_is_admitted():
+    # The reader rebuilds a nested model from a mapping, so a serializer that
+    # says it returns one is fine; only one that says otherwise, or says
+    # nothing, is refused.
+    assert python_to_sql(list[MappingDump | None]).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "JSON", "dc_nullable": True},
+    }
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        pytest.param(tuple[Literal[1, "1"], SlotA], id="refused-slot-beside-a-model"),
+        pytest.param(tuple[SlotA | None, str], id="string-slot-beside-a-model"),
+    ],
+)
+def test_a_non_model_slot_is_resolved_before_json_is_chosen(annotation):
+    # The model branch used to return JSON without looking at the other slots,
+    # so a refusal was skipped and a bare string was stored where reading it
+    # back raises.
+    with pytest.raises(TypeError):
+        python_to_sql(annotation)

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -667,11 +667,26 @@ class MappingDump(BaseModel):
         return {"x": self.x}
 
 
-def test_a_serializer_returning_a_mapping_is_admitted():
+class MappingDumpByDecorator(BaseModel):
+    x: int
+
+    @model_serializer(return_type=dict[str, int])
+    def _dump(self):
+        return {"x": self.x}
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(MappingDump, id="annotated-return"),
+        pytest.param(MappingDumpByDecorator, id="return_type-argument"),
+    ],
+)
+def test_a_serializer_returning_a_mapping_is_admitted(model):
     # The reader rebuilds a nested model from a mapping, so a serializer that
-    # says it returns one is fine; only one that says otherwise, or says
-    # nothing, is refused.
-    assert python_to_sql(list[MappingDump | None]).to_dict() == {
+    # says it returns one is fine, however it says so; only one that says
+    # otherwise, or says nothing, is refused.
+    assert python_to_sql(list[model | None]).to_dict() == {
         "type": "Array",
         "item_type": {"type": "JSON", "dc_nullable": True},
     }
@@ -682,6 +697,7 @@ def test_a_serializer_returning_a_mapping_is_admitted():
     [
         pytest.param(tuple[Literal[1, "1"], SlotA], id="refused-slot-beside-a-model"),
         pytest.param(tuple[SlotA | None, str], id="string-slot-beside-a-model"),
+        pytest.param(tuple[SlotA | None, datetime], id="datetime-slot-beside-a-model"),
     ],
 )
 def test_a_non_model_slot_is_resolved_before_json_is_chosen(annotation):
@@ -690,3 +706,13 @@ def test_a_non_model_slot_is_resolved_before_json_is_chosen(annotation):
     # back raises.
     with pytest.raises(TypeError):
         python_to_sql(annotation)
+
+
+def test_a_null_only_slot_beside_a_model_is_not_mistaken_for_a_string():
+    # Literal[None] borrows String as a placeholder column type; it stores
+    # nothing, so the check that refuses a bare string beside a model does not
+    # apply to it.
+    assert python_to_sql(tuple[Literal[None], SlotA]).to_dict() == {  # noqa: PYI061
+        "type": "Array",
+        "item_type": {"type": "JSON", "dc_nullable": True},
+    }

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -17,7 +17,7 @@ from pydantic import (
 
 import datachain as dc
 from datachain import json as dcjson
-from datachain.lib.convert.python_to_sql import python_to_sql
+from datachain.lib.convert.python_to_sql import _model_element, python_to_sql
 from datachain.sql.types import (
     JSON,
     Array,
@@ -613,3 +613,28 @@ def test_python_to_sql_refuses_a_model_that_does_not_dump_to_a_mapping():
     # returning something else would be stored and handed back as that instead.
     with pytest.raises(TypeError):
         python_to_sql(list[ScalarDump | None])
+
+
+def test_a_required_model_slot_is_held_to_the_same_contract():
+    # Asking only of the optional slots let a required one through on the
+    # strength of its neighbour; both answer to "the reader can rebuild it".
+    assert _model_element(SlotA) is SlotA
+    assert _model_element(SlotA | None) is SlotA
+    assert _model_element(ScalarDump) is None
+    assert _model_element(ScalarDump | None) is None
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        pytest.param(tuple[SlotA, int], id="model-first"),
+        pytest.param(tuple[int, SlotA], id="model-second"),
+    ],
+)
+def test_a_mixed_tuple_falls_back_to_json_whichever_slot_is_the_model(annotation):
+    # Resolving the first slot outside the fallback made one order raise and the
+    # other work.
+    assert python_to_sql(annotation).to_dict() == {
+        "type": "Array",
+        "item_type": {"type": "JSON"},
+    }

--- a/tests/func/test_data_storage.py
+++ b/tests/func/test_data_storage.py
@@ -625,16 +625,35 @@ def test_a_required_model_slot_is_held_to_the_same_contract():
 
 
 @pytest.mark.parametrize(
-    "annotation",
+    "annotation,expected",
     [
-        pytest.param(tuple[SlotA, int], id="model-first"),
-        pytest.param(tuple[int, SlotA], id="model-second"),
+        pytest.param(tuple[SlotA, int], {"type": "JSON"}, id="model-first"),
+        pytest.param(tuple[int, SlotA], {"type": "JSON"}, id="model-second"),
+        pytest.param(
+            tuple[SlotA | None, int],
+            {"type": "JSON", "dc_nullable": True},
+            id="optional-model-first",
+        ),
+        pytest.param(
+            tuple[int, SlotA | None],
+            {"type": "JSON", "dc_nullable": True},
+            id="optional-model-second",
+        ),
     ],
 )
-def test_a_mixed_tuple_falls_back_to_json_whichever_slot_is_the_model(annotation):
-    # Resolving the first slot outside the fallback made one order raise and the
-    # other work.
+def test_a_mixed_tuple_reaches_the_same_type_whichever_slot_is_the_model(
+    annotation, expected
+):
+    # Returning early on the mixed case skipped the nullability step, so a
+    # nullable slot lost its marker depending on where it sat.
     assert python_to_sql(annotation).to_dict() == {
         "type": "Array",
-        "item_type": {"type": "JSON"},
+        "item_type": expected,
     }
+
+
+def test_a_model_beside_a_scalar_is_still_held_to_the_contract():
+    # The mixed case must not be a way past the check: this slot holds a model
+    # the reader cannot rebuild, whatever sits next to it.
+    with pytest.raises(TypeError):
+        python_to_sql(tuple[ScalarDump | None, int])


### PR DESCRIPTION
Stacked on #1976.

`is_chain_type` accepts `list[Child | None]`, and `list[Child]` writes, but
building the schema raised:

```python
class Child(dc.DataModel):
    x: int

class Holder(dc.DataModel):
    vals: list[Child | None]

chain.map(h=..., output=Holder)
# TypeError: Cannot recognize type <class 'Child'>
```

The check that maps a model element to JSON read the annotation as written, and
the union arm was all that hid the model. It asks what the arm holds now, and
marks the element nullable so the array carries the `None` rather than the
document. With #1978's `flatten` fix in place, all three orders round-trip:

```
[Child(x=1), None]  ->  [Child(x=1), None]
[None, Child(x=2)]  ->  [None, Child(x=2)]
[None, None]        ->  [None, None]
```

## Every slot, not the first

The model check used to answer from `args[0]` and return, leaving the rest of a
fixed tuple unexamined — so `tuple[A, B | None]` lost its `dc_nullable`, and
`tuple[A, RootInt | None]` was accepted although its second slot leaf-reads as a
bare integer. There is one check now, over every slot. A whole-model read hides
this class of mistake, because Pydantic revalidates the dict; only a leaf read
shows it.

## What stays refused

Admission requires a model the reader can rebuild — that is, one that
**serializes as a mapping**:

| annotation | why refused |
| --- | --- |
| `list[Annotated[Child, "meta"] \| None]` | rebuilding a nested model does not look through `Annotated`; comes back as `[None, {'x': 1}]` |
| `list[RootModel[int] \| None]` | a root model dumps to its bare value; comes back as `[None, 1]` |
| `list[ScalarDump \| None]` | a `model_serializer` returning a scalar; leaf-reads as `[None, 7]` and whole-model reading raises |

`"is a BaseModel and is not a RootModel"` was too weak a contract for the last of
those.

`Model | Literal[None]` is also not admitted. It resolves and reads exactly as on
`main` — as plain dicts — and admitting it here would store models the reader
cannot rebuild, for the same reason as the first row. Making that spelling work
is hydration's side.

## Inherited limitation

`list[Model | None]` goes through `flatten`, which dumps a model in Pydantic's
**python mode**, so a field the project's own encoder cannot write fails there —
`Path`, `bytes`, and `Decimal` lossily:

```
list[Child]         Child(path=Path("a/b"))   TypeError: PosixPath is not JSON serializable   # on main too
list[Child | None]  [None, Child(path=...)]   same
tuple[Child, Child] Child(path=Path("a/b"))   works — that shape uses JSON mode
```

This is not introduced here: `list[Child]` fails identically on `main`, and the
tuple shapes are unchanged across the whole stack. What the PR does is make
`list[Model | None]` reachable, so it inherits exactly what `list[Model]` already
had. The two converters disagreeing about which types they can write is
[#1968](https://github.com/datachain-ai/datachain/issues/1968); this PR does not
narrow that gap, and does not widen it either.

## Compatibility

Nothing that already wrote is affected: every annotation admitted here raised
before, so there is no stored form to stay compatible with.

## Stack

1. #1963 — variadic tuple element type, physical fingerprint
2. #1978 — canonical array conversion, codec version
3. #1976 — nullable element spellings, nullable-collection fallback
4. **this PR** — optional model elements

