### PR TITLE
fix: clarify stale-catalog etag error with update=True and ISO timestamps

### DIFF
--- a/src/datachain/client/fsspec.py
+++ b/src/datachain/client/fsspec.py
@@ -10,7 +10,7 @@ import shutil
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterator, Sequence
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, BinaryIO, ClassVar, Literal, NamedTuple
 from urllib.parse import urlparse
 
@@ -42,6 +42,16 @@ DATA_SOURCE_URI_PATTERN = re.compile(r"^[\w]+:\/\/.*$")
 CLOUD_STORAGE_PROTOCOLS = {"s3", "gs", "az", "hf"}
 
 ResultQueue = asyncio.Queue[Sequence["File"] | None]
+
+
+def _format_etag(etag: str) -> str:
+    if etag.startswith(("0x", "-0x")):
+        try:
+            mtime = float.fromhex(etag)
+        except ValueError:
+            return etag
+        return datetime.fromtimestamp(mtime, timezone.utc).isoformat()
+    return etag
 
 
 def is_cloud_uri(uri: str) -> bool:
@@ -578,7 +588,10 @@ class Client(ABC):
             etag = await self.get_current_etag(file)
             if file.etag != etag:
                 raise FileNotFoundError(
-                    f"Invalid etag for {file.source}/{file.path}: "
-                    f"expected {file.etag}, got {etag}"
+                    f"{file.source}/{file.path} changed on the source since the "
+                    f"catalog was created (etag was {_format_etag(file.etag)}, now "
+                    f"{_format_etag(etag)}). "
+                    f"Run dc.read_storage('{file.source}', update=True) to refresh "
+                    f"the catalog."
                 )
         await self.cache.download(file, self, callback=callback)

--- a/tests/unit/test_client_local.py
+++ b/tests/unit/test_client_local.py
@@ -1,8 +1,10 @@
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
+from datachain.client.fsspec import _format_etag
 from datachain.client.local import FileClient
 from datachain.client.writeconfig import WriteConfig
 from datachain.fs.utils import path_to_fsspec_uri
@@ -19,6 +21,47 @@ def test_write_kwargs_ignores_all_fields(streaming):
         write_options={"ACL": "public-read"},
     )
     assert FileClient._write_kwargs(cfg, streaming=streaming) == {}
+
+
+def test_format_etag_renders_mtime_hex_as_iso_timestamp():
+    mtime = 1234567890.25
+    expected = datetime.fromtimestamp(mtime, timezone.utc).isoformat()
+    assert _format_etag(mtime.hex()) == expected
+
+
+@pytest.mark.parametrize(
+    "etag",
+    [
+        "d41d8cd98f00b204e9800998ecf8427e",
+        '"abc123"',
+        "abc",
+        "0xzz",
+    ],
+)
+def test_format_etag_passthrough_for_non_timestamp_etags(etag):
+    assert _format_etag(etag) == etag
+
+
+def test_put_in_cache_stale_etag_guides_update(tmp_path, catalog):
+    client = FileClient.from_source(str(tmp_path), catalog.cache)
+
+    rel_path = "folder/file.bin"
+    fpath = Path(tmp_path, rel_path)
+    fpath.parent.mkdir(parents=True)
+    fpath.write_bytes(b"hello")
+
+    current_etag = fpath.stat().st_mtime.hex()
+    stale_etag = (fpath.stat().st_mtime - 1).hex()
+    assert stale_etag != current_etag
+
+    file = File(source=client.uri, path=rel_path, etag=stale_etag)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        client.put_in_cache(file)
+
+    message = str(excinfo.value)
+    assert rel_path in message
+    assert "update=True" in message
+    assert stale_etag not in message
 
 
 def test_split_url_directory_preserves_leaf(tmp_path):


### PR DESCRIPTION
Closes #1906

## Problem

Reading a file from a stale catalog raises a `FileNotFoundError` that shows two raw hex-float etags (`0x1.aa754b8df8169p+30`), with no indication that the catalog is out of date or how to recover.

## Root cause

For local files, `FileClient` derives the etag from the file's mtime as a hex float (`src/datachain/client/local.py:222`). When a file changes after the listing was created, `Client._put_in_cache` correctly detects the mismatch but renders the diagnostic in raw mtime hex.

## Fix

- Render hex-float (mtime) etags in the error as ISO-8601 timestamps; non-timestamp etags (cloud hashes, quoted etags, …) pass through unchanged.
- Tell the user the catalog is stale and how to refresh it: `dc.read_storage("<uri>", update=True)`, matching the phrasing already used in the docs.

## Verification

- New unit tests cover the formatter (mtime hex → ISO round-trip; passthrough for non-timestamp etags) and the raised error (names the file, hides raw hex etags, mentions `update=True`).
- Reproduced the original failure with a stale local listing before the change; after the change the message reads:

```
<path> changed on the source since the catalog was created
(etag was 2026-09-06T11:50:45.943065+00:00, now 2026-09-06T11:50:46.334246+00:00).
Run dc.read_storage('<uri>', update=True) to refresh the catalog.
```

- `tests/unit/test_client_local.py` and the client unit suites pass; `ruff check` and `ruff format` are clean.