### PR TITLE
Drop the cleanup_for_tests hook and wipe test databases from the fixtures instead

### DIFF
--- a/.github/workflows/tests-studio.yml
+++ b/.github/workflows/tests-studio.yml
@@ -30,7 +30,7 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_USER: test
-          POSTGRES_DB: database
+          POSTGRES_DB: datachain_saas_test
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --add-host=host.docker.internal:host-gateway
@@ -40,7 +40,7 @@ jobs:
           - 8123:8123
           - 9010:9000
         env:
-          CLICKHOUSE_DB: studio_local_db
+          CLICKHOUSE_DB: datachain_saas_test
           CLICKHOUSE_USER: studio_local
           CLICKHOUSE_PASSWORD: ch123456789!
           CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1

--- a/src/datachain/data_storage/metastore.py
+++ b/src/datachain/data_storage/metastore.py
@@ -148,9 +148,6 @@ class AbstractMetastore(ABC, Serializable):
     def cleanup_tables(self, temp_table_names: list[str]) -> None:
         """Cleanup temp tables."""
 
-    def cleanup_for_tests(self) -> None:
-        """Cleanup for tests."""
-
     #
     # Namespaces
     #

--- a/src/datachain/data_storage/warehouse.py
+++ b/src/datachain/data_storage/warehouse.py
@@ -86,9 +86,6 @@ class AbstractWarehouse(ABC, Serializable):
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         """Default behavior is to do nothing, as connections may be shared."""
 
-    def cleanup_for_tests(self):
-        """Cleanup for tests."""
-
     def normalize_limit_offset(self, query: GenerativeSelect) -> GenerativeSelect:
         """Return query adjusted for warehouse-specific LIMIT/OFFSET semantics."""
         return query

--- a/src/datachain/testing.py
+++ b/src/datachain/testing.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+
+if TYPE_CHECKING:
+    from datachain.data_storage.db_engine import DatabaseEngine
+
+
+def drop_all_tables(db: "DatabaseEngine") -> None:
+    """Drop every table in the test database behind ``db``.
+
+    For server backends whose engine URL names the database; SQLite engines
+    connect through a creator and have no URL database to check.
+    """
+    database = db.engine.url.database or ""
+    if "test" not in database:
+        raise RuntimeError(
+            f"Refusing to wipe database {database!r}: the name must contain 'test'"
+        )
+    metadata = sa.MetaData()
+    metadata.reflect(bind=db.engine)
+    quote = db.dialect.identifier_preparer.quote
+    with db.engine.begin() as conn:
+        for table in reversed(metadata.sorted_tables):
+            conn.execute(sa.text(f"DROP TABLE IF EXISTS {quote(table.name)}"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ from datachain.lib.dc import Sys
 from datachain.namespace import Namespace
 from datachain.project import Project
 from datachain.query.session import Session
+from datachain.testing import drop_all_tables
 from datachain.utils import (
     ENV_DATACHAIN_GLOBAL_CONFIG_DIR,
     ENV_DATACHAIN_SYSTEM_CONFIG_DIR,
@@ -203,7 +204,7 @@ def metastore(monkeypatch):
         yield _metastore
 
         Session.cleanup_for_tests()
-        _metastore.cleanup_for_tests()
+        drop_all_tables(_metastore.db)
     else:
         _metastore = SQLiteMetastore(db_file=":memory:")
         yield _metastore
@@ -253,7 +254,7 @@ def warehouse(metastore):
             check_temp_tables_cleaned_up(_warehouse)
         finally:
             cleanup_udf_tables(_warehouse)
-            _warehouse.cleanup_for_tests()
+            drop_all_tables(_warehouse.db)
         yield _warehouse
     else:
         _warehouse = SQLiteWarehouse(db_file=":memory:")
@@ -297,7 +298,7 @@ def metastore_tmpfile(monkeypatch, tmp_path):
         yield _metastore
 
         Session.cleanup_for_tests()
-        _metastore.cleanup_for_tests()
+        drop_all_tables(_metastore.db)
     else:
         _metastore = SQLiteMetastore(db_file=str(tmp_path / "test.db"))
         yield _metastore
@@ -319,7 +320,7 @@ def warehouse_tmpfile(tmp_path, metastore_tmpfile):
             check_temp_tables_cleaned_up(_warehouse)
         finally:
             cleanup_udf_tables(_warehouse)
-            _warehouse.cleanup_for_tests()
+            drop_all_tables(_warehouse.db)
         yield _warehouse
     else:
         _warehouse = SQLiteWarehouse(db_file=str(tmp_path / "test.db"))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -654,6 +654,9 @@ def test_drop_all_tables_refuses_non_test_database():
 
 def test_drop_all_tables_drops_fk_linked_tables(tmp_path):
     engine = sa.create_engine(f"sqlite:///{tmp_path}/test.db")
+    sa.event.listen(
+        engine, "connect", lambda conn, _: conn.execute("PRAGMA foreign_keys = ON")
+    )
     metadata = sa.MetaData()
     parents = sa.Table(
         "parents", metadata, sa.Column("id", sa.Integer, primary_key=True)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,10 +1,13 @@
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from filelock import FileLock, Timeout
+from sqlalchemy.engine import make_url
 
 from datachain.fs.utils import is_subpath, path_to_fsspec_uri
+from datachain.testing import drop_all_tables
 from datachain.utils import (
     batched,
     batched_it,
@@ -637,3 +640,12 @@ def test_path_to_fsspec_uri_colon_in_filename_is_local(path):
 def test_path_to_fsspec_uri_passes_through_real_uris(uri):
     """URIs with a ``scheme://`` prefix must pass through unchanged."""
     assert path_to_fsspec_uri(uri) == uri
+
+
+def test_drop_all_tables_refuses_non_test_database():
+    db = SimpleNamespace(
+        engine=SimpleNamespace(url=make_url("postgresql://x@localhost/database"))
+    )
+
+    with pytest.raises(RuntimeError, match="must contain 'test'"):
+        drop_all_tables(db)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import sqlalchemy as sa
 from filelock import FileLock, Timeout
 from sqlalchemy.engine import make_url
 
@@ -649,3 +650,25 @@ def test_drop_all_tables_refuses_non_test_database():
 
     with pytest.raises(RuntimeError, match="must contain 'test'"):
         drop_all_tables(db)
+
+
+def test_drop_all_tables_drops_fk_linked_tables(tmp_path):
+    engine = sa.create_engine(f"sqlite:///{tmp_path}/test.db")
+    metadata = sa.MetaData()
+    parents = sa.Table(
+        "parents", metadata, sa.Column("id", sa.Integer, primary_key=True)
+    )
+    children = sa.Table(
+        "children",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("parent_id", sa.ForeignKey("parents.id")),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(parents.insert().values(id=1))
+        conn.execute(children.insert().values(id=1, parent_id=1))
+
+    drop_all_tables(SimpleNamespace(engine=engine, dialect=engine.dialect))
+
+    assert sa.inspect(engine).get_table_names() == []

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -675,3 +675,4 @@ def test_drop_all_tables_drops_fk_linked_tables(tmp_path):
     drop_all_tables(SimpleNamespace(engine=engine, dialect=engine.dialect))
 
     assert sa.inspect(engine).get_table_names() == []
+    engine.dispose()


### PR DESCRIPTION
`AbstractMetastore` and `AbstractWarehouse` carried a `cleanup_for_tests()` hook whose only purpose was to let an external backend (Studio) drop its tables between tests. That put test-only, destructive code into production classes, and every backend had to reimplement the wipe.

The test fixtures now do it themselves through a single shared helper, `datachain.testing.drop_all_tables(db)`. It reflects the schema for FK ordering and issues `DROP TABLE IF EXISTS` for every table through the engine connection, so it works for any `DatabaseEngine`. It refuses to run against a database whose name does not contain `test`. The hook is deleted from both base classes.

The helper ships in the package, as `datachain.testing`, so that Studio can import it instead of carrying a copy.

The SQLite fixtures are unchanged.

See also related PR in Studio repo (upcoming).

<sub>🤖 Co-authored by Claude Code and Codex</sub>