### PR TITLE
Show how long each job stage took under `job ls -e`

### DIFF
--- a/src/datachain/cli/parser/job.py
+++ b/src/datachain/cli/parser/job.py
@@ -167,7 +167,7 @@ def add_jobs_parser(subparsers, parent_parser) -> None:
         "--extended",
         action="store_true",
         default=False,
-        help="Show extra job details, such as the compute cluster",
+        help="Show extra job details",
     )
 
     studio_cancel_help = "Cancel a job in Studio"

--- a/src/datachain/remote/studio.py
+++ b/src/datachain/remote/studio.py
@@ -519,12 +519,15 @@ class StudioClient:
         status: str | None = None,
         limit: int = 20,
         job_id: str | None = None,
+        include_steps: bool = False,
     ) -> Response[JobListData]:
         params: dict[str, Any] = {"limit": limit}
         if status is not None:
             params["status"] = status
         if job_id is not None:
             params["job_id"] = job_id
+        if include_steps:
+            params["include_steps"] = True
         return self._send_request("datachain/jobs/", params, method="GET")
 
     def cancel_job(

--- a/src/datachain/studio.py
+++ b/src/datachain/studio.py
@@ -745,7 +745,7 @@ def list_jobs(
     status: str | None, team_name: str | None, limit: int, extended: bool = False
 ):
     client = StudioClient(team=team_name)
-    response = client.get_jobs(status, limit)
+    response = client.get_jobs(status, limit, include_steps=extended)
     if not response.ok:
         raise DataChainError(response.message)
 
@@ -765,9 +765,36 @@ def list_jobs(
         }
         if extended:
             row["Cluster"] = job.get("compute_cluster_name")
+            row["Stages"] = _format_stages(job.get("steps") or [])
         rows.append(row)
 
     print(tabulate.tabulate(rows, headers="keys", tablefmt="grid"))
+
+
+def _format_stages(steps: list[dict]) -> str:
+    return "\n".join(
+        f"{step.get('label') or step.get('name')}: {_stage_duration(step)}"
+        for step in steps
+    )
+
+
+def _stage_duration(step: dict) -> str:
+    started, finished = step.get("started_at"), step.get("finished_at")
+    if not started:
+        return "-"
+    if not finished:
+        return "running"
+
+    seconds = int(
+        (
+            datetime.fromisoformat(finished) - datetime.fromisoformat(started)
+        ).total_seconds()
+    )
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m {seconds % 60}s"
+    return f"{seconds // 3600}h {seconds % 3600 // 60}m"
 
 
 def show_job_logs(job_id: str, team_name: str | None):

--- a/tests/test_cli_studio.py
+++ b/tests/test_cli_studio.py
@@ -707,6 +707,22 @@ def test_studio_list_jobs(capsys):
                     "compute_cluster_name": "dev-cluster",
                     "created_at": "2021-01-02T00:00:00Z",
                     "created_by": "user",
+                    "steps": [
+                        {
+                            "name": "virtualenv",
+                            "label": "Installing dependencies",
+                            "status": "FINISHED",
+                            "started_at": "2021-01-02T00:00:00Z",
+                            "finished_at": "2021-01-02T00:02:30Z",
+                        },
+                        {
+                            "name": "running_query",
+                            "label": "Running query",
+                            "status": "STARTED",
+                            "started_at": "2021-01-02T00:02:30Z",
+                            "finished_at": None,
+                        },
+                    ],
                 },
             ],
         )
@@ -715,11 +731,16 @@ def test_studio_list_jobs(capsys):
         out = capsys.readouterr().out
         assert "Cluster" not in out
         assert "prod-cluster" not in out
+        assert "include_steps" not in m.last_request.qs
 
         assert main(["job", "ls", "--extended"]) == 0
         out = capsys.readouterr().out
         assert "Cluster" in out
         assert "prod-cluster" in out
+        assert m.last_request.qs["include_steps"] == ["true"]
+        assert "Installing dependencies: 2m 30s" in out
+        # A stage still going must be distinguishable from one that took no time.
+        assert "Running query: running" in out
 
 
 def test_studio_cancel_job(capsys, mocker):


### PR DESCRIPTION
Companion to datachain-ai/studio#13242, which serves a job's stages when asked for
them. Needs that merged and deployed first; until then `-e` behaves exactly as it does
today, since Studio simply omits the field.

### Why

`datachain job ls` shows when a job was created and what became of it. That does not
distinguish a job which sat in a queue for an hour from one that ran for an hour, so
anyone working out where the time went had to open the job page.

### What

`-e` already meant "show me more", so the stages go there rather than behind a new
flag:

```
+----------+-------------+----------+--------------+-----------+---------------------------------+
| ID       | Name        | Status   | Created by   | Cluster   | Stages                          |
+==========+=============+==========+==============+===========+=================================+
| 8bddde6c | nightly-etl | RUNNING  | ivan         | prod      | Waiting in queue: 4s            |
|          |             |          |              |           | Starting workers: 35s           |
|          |             |          |              |           | Installing dependencies: 2m 30s |
|          |             |          |              |           | Running query: running          |
+----------+-------------+----------+--------------+-----------+---------------------------------+
```

- **Named as the job page names them.** Studio sends both the stable `name` and the
  `label` the UI shows; this renders the label so a terminal and the web page call the
  same thing the same thing, and falls back to the name for a stage this version has
  not heard of.
- **A stage still going says `running`** rather than reporting no time.
- **Only fetched with `-e`.** `get_jobs()` gains `include_steps`, passed only when
  extended, so the default listing is the same request it has always been.

`StudioClient.get_jobs(include_steps=True)` is also what a script would call to do its
own accounting — the durations here are formatted for reading, and the raw timestamps
come through untouched for anything that wants to compute with them.

### Tests

No new test: `test_studio_list_jobs` is already the test for `-e`, so the stages went
into its fixture and its assertions — the labels, the duration formats, a stage still
running, and `include_steps` being absent from the query without `-e` and `true` with
it. 65 passed in `tests/test_cli_studio.py`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
